### PR TITLE
fix: minor bug fixes

### DIFF
--- a/includes/newspack-listings-utils.php
+++ b/includes/newspack-listings-utils.php
@@ -107,7 +107,7 @@ function get_data_from_blocks( $blocks, $source ) {
 		}
 
 		// If the source has 'single' specified, only get data from the first found block instance.
-		if ( $source['single'] ) {
+		if ( isset( $source['single'] ) && ! empty( $source['single'] ) ) {
 			$matching_blocks = array_slice( $matching_blocks, 0, 1 );
 		}
 
@@ -138,7 +138,7 @@ function get_data_from_blocks( $blocks, $source ) {
 	}
 
 	// If the source has 'single' specified, only return data from the first found block instance.
-	if ( $source['single'] ) {
+	if ( isset( $source['single'] ) && ! empty( $source['single'] ) ) {
 		return array_shift( $data );
 	}
 

--- a/includes/newspack-listings-utils.php
+++ b/includes/newspack-listings-utils.php
@@ -107,7 +107,7 @@ function get_data_from_blocks( $blocks, $source ) {
 		}
 
 		// If the source has 'single' specified, only get data from the first found block instance.
-		if ( isset( $source['single'] ) && ! empty( $source['single'] ) ) {
+		if ( ! empty( $source['single'] ) ) {
 			$matching_blocks = array_slice( $matching_blocks, 0, 1 );
 		}
 
@@ -138,7 +138,7 @@ function get_data_from_blocks( $blocks, $source ) {
 	}
 
 	// If the source has 'single' specified, only return data from the first found block instance.
-	if ( isset( $source['single'] ) && ! empty( $source['single'] ) ) {
+	if ( ! empty( $source['single'] ) ) {
 		return array_shift( $data );
 	}
 

--- a/src/components/sidebar-query-controls.js
+++ b/src/components/sidebar-query-controls.js
@@ -188,7 +188,7 @@ class QueryControls extends Component {
 		}
 
 		// Enable listing type option only if there's more than one listing type in the list.
-		if ( 'any' === type ) {
+		if ( 'any' === type || ! type ) {
 			sortOptions.push( { label: __( 'Listing Type', 'newspack-listings' ), value: 'type' } );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two minor bugs:

1. When syncing metadata, avoid a PHP warning when the `single` key is not set in the metadata config array. This happens when syncing metadata that supports syncing data from multiple instances of a block, and the metadata config array in the newspack-listings-core.php file doesn't include the `'single' key.
2. When creating a new list in Query mode, "Listing Type" is now available as a default Sort By option (as "Any" is the default listing type).

Closes #18.

### How to test the changes in this Pull Request:

#### Testing the meta sync bug

1. Start out on the `master` branch.
2. Create a new Event listing post and add an a.) Event Dates block and b.) more than one Jetpack Contact Info block. Fill in data for all blocks.
3. Attempt to save or publish the post, and observe a PHP warning like `PHP Notice:  Undefined index: single in /Users/dkoo/Local Sites/newspack/app/public/wp-content/plugins/newspack-listings/includes/newspack-listings-utils.php on line 141` that prevents the post from being saved.
4. Check out this branch and run `npm run build`.
5. Attempt to save or publish the post again, confirm that the PHP warning does not occur and the post is saved successfully. Reload the post and confirm that your data has been actually saved.

#### Testing the Sort By option

1. Create a new Curated List block and choose Query mode.
2. Under Query Settings, expand "Show advanced filters" and observe that the "Sort By" dropdown include a Listing Type option.
3. Set the "Listing Type" option to something other than "Any" and confirm that "Sort By" option no longer includes the Listing Type option.
4. Set "Listing Type" to "Any" again and confirm once more that the "Sort By" dropdown include a Listing Type option.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
