### PR TITLE
feat: listing post enhancements

### DIFF
--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -141,7 +141,8 @@ final class Newspack_Listings_Core {
 	 * After WP init, register all the necessary post types and blocks.
 	 */
 	public static function register_post_types() {
-		$prefix            = Settings::get_settings( 'permalink_prefix' );
+		$settings          = Settings::get_settings();
+		$prefix            = $settings['newspack_listings_permalink_prefix'];
 		$default_config    = [
 			'has_archive'  => false,
 			'public'       => true,
@@ -169,7 +170,7 @@ final class Newspack_Listings_Core {
 					'not_found'          => __( 'No events found.', 'newspack-listings' ),
 					'not_found_in_trash' => __( 'No events found in Trash.', 'newspack-listings' ),
 				],
-				'rewrite'  => [ 'slug' => $prefix . '/' . self::NEWSPACK_LISTINGS_PERMALINK_SLUGS['event'] ],
+				'rewrite'  => [ 'slug' => $prefix . '/' . $settings['newspack_listings_event_slug'] ],
 				'template' => [ [ 'newspack-listings/event-dates' ] ],
 			],
 			'generic'     => [
@@ -189,7 +190,7 @@ final class Newspack_Listings_Core {
 					'not_found'          => __( 'No listings found.', 'newspack-listings' ),
 					'not_found_in_trash' => __( 'No listings found in Trash.', 'newspack-listings' ),
 				],
-				'rewrite' => [ 'slug' => $prefix . '/' . self::NEWSPACK_LISTINGS_PERMALINK_SLUGS['generic'] ],
+				'rewrite' => [ 'slug' => $prefix . '/' . $settings['newspack_listings_generic_slug'] ],
 			],
 			'marketplace' => [
 				'labels'  => [
@@ -208,7 +209,7 @@ final class Newspack_Listings_Core {
 					'not_found'          => __( 'No Marketplace listings found.', 'newspack-listings' ),
 					'not_found_in_trash' => __( 'No Marketplace listings found in Trash.', 'newspack-listings' ),
 				],
-				'rewrite' => [ 'slug' => $prefix . '/' . self::NEWSPACK_LISTINGS_PERMALINK_SLUGS['marketplace'] ],
+				'rewrite' => [ 'slug' => $prefix . '/' . $settings['newspack_listings_marketplace_slug'] ],
 			],
 			'place'       => [
 				'labels'  => [
@@ -227,13 +228,13 @@ final class Newspack_Listings_Core {
 					'not_found'          => __( 'No places found.', 'newspack-listings' ),
 					'not_found_in_trash' => __( 'No places found in Trash.', 'newspack-listings' ),
 				],
-				'rewrite' => [ 'slug' => $prefix . '/' . self::NEWSPACK_LISTINGS_PERMALINK_SLUGS['place'] ],
+				'rewrite' => [ 'slug' => $prefix . '/' . $settings['newspack_listings_place_slug'] ],
 			],
 		];
 
 		foreach ( $post_types_config as $post_type_slug => $post_type_config ) {
 			$post_type = self::NEWSPACK_LISTINGS_POST_TYPES[ $post_type_slug ];
-			$permalink = self::NEWSPACK_LISTINGS_PERMALINK_SLUGS[ $post_type_slug ];
+			$permalink = reset( $post_type_config['rewrite'] );
 
 			// Register the post type.
 			register_post_type( $post_type, wp_parse_args( $post_type_config, $default_config ) );
@@ -249,7 +250,7 @@ final class Newspack_Listings_Core {
 			}
 
 			// Create a rewrite rule to handle the prefixed permalink.
-			add_rewrite_rule( '^' . $prefix . '/' . $permalink . '/([^/]+)/?$', 'index.php?name=$matches[1]&post_type=' . $post_type, 'top' );
+			add_rewrite_rule( '^' . $permalink . '/([^/]+)/?$', 'index.php?name=$matches[1]&post_type=' . $post_type, 'top' );
 		}
 	}
 
@@ -516,8 +517,8 @@ final class Newspack_Listings_Core {
 				'label'      => __( 'Hide listing author', 'newspack-listings' ),
 				'settings'   => [
 					'object_subtype'    => $post_type,
-					'default'           => false,
-					'description'       => __( 'Hide the author for this listing?', 'newspack-listings' ),
+					'default'           => Settings::get_settings( 'newspack_listings_hide_author' ), // Configurable in plugin-wide settings.
+					'description'       => __( 'Hide author byline and bio for this listing', 'newspack-listings' ),
 					'type'              => 'boolean',
 					'sanitize_callback' => 'rest_sanitize_boolean',
 					'single'            => true,

--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -68,7 +68,7 @@ final class Newspack_Listings_Core {
 	public function __construct() {
 		add_action( 'admin_menu', [ __CLASS__, 'add_plugin_page' ] );
 		add_action( 'init', [ __CLASS__, 'register_post_types' ] );
-		add_action( 'post_insert', [ __CLASS__, 'set_default_template' ] );
+		add_action( 'wp_insert_post', [ __CLASS__, 'set_default_template' ], 10, 3 );
 		add_filter( 'body_class', [ __CLASS__, 'set_template_class' ] );
 		add_action( 'save_post', [ __CLASS__, 'sync_post_meta' ], 10, 2 );
 		add_filter( 'newspack_listings_hide_author', [ __CLASS__, 'hide_author' ] );
@@ -662,6 +662,8 @@ final class Newspack_Listings_Core {
 			$template = get_page_template_slug();
 			if ( 'single-feature.php' === $template ) {
 				$classes[] = 'post-template-single-feature';
+			} elseif ( 'single-wide.php' === $template ) {
+				$classes[] = 'post-template-single-wide';
 			}
 		}
 
@@ -675,11 +677,10 @@ final class Newspack_Listings_Core {
 	 * @return array Filtered array of supported post types.
 	 */
 	public static function support_featured_image_options( $post_types ) {
-		if ( self::is_listing() ) {
-			$post_types = array_merge( $post_types, array_values( self::NEWSPACK_LISTINGS_POST_TYPES ) );
-		}
-
-		return $post_types;
+		return array_merge(
+			$post_types,
+			array_values( self::NEWSPACK_LISTINGS_POST_TYPES )
+		);
 	}
 
 	/**

--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -68,9 +68,11 @@ final class Newspack_Listings_Core {
 	public function __construct() {
 		add_action( 'admin_menu', [ __CLASS__, 'add_plugin_page' ] );
 		add_action( 'init', [ __CLASS__, 'register_post_types' ] );
-		add_filter( 'single_template', [ __CLASS__, 'set_default_template' ] );
+		add_action( 'post_insert', [ __CLASS__, 'set_default_template' ] );
+		add_filter( 'body_class', [ __CLASS__, 'set_template_class' ] );
 		add_action( 'save_post', [ __CLASS__, 'sync_post_meta' ], 10, 2 );
 		add_filter( 'newspack_listings_hide_author', [ __CLASS__, 'hide_author' ] );
+		add_filter( 'newspack_theme_featured_image_post_types', [ __CLASS__, 'support_featured_image_options' ] );
 		register_activation_hook( NEWSPACK_LISTINGS_FILE, [ __CLASS__, 'activation_hook' ] );
 	}
 
@@ -146,7 +148,7 @@ final class Newspack_Listings_Core {
 			'show_in_menu' => 'newspack-listings',
 			'show_in_rest' => true,
 			'show_ui'      => true,
-			'supports'     => [ 'editor', 'excerpt', 'title', 'author', 'custom-fields', 'thumbnail' ],
+			'supports'     => [ 'editor', 'excerpt', 'title', 'author', 'custom-fields', 'thumbnail', 'newspack-blocks' ],
 			'taxonomies'   => [ 'category', 'post_tag' ],
 		];
 		$post_types_config = [
@@ -581,8 +583,8 @@ final class Newspack_Listings_Core {
 	 * Sync data from specific content blocks to post meta.
 	 * Source blocks for each meta field are set in the meta config above.
 	 *
-	 * @param int   $post_id ID of the post being created or updated.
-	 * @param array $post Post object of the post being created or updated.
+	 * @param int    $post_id ID of the post being created or updated.
+	 * @param object $post Post object of the post being created or updated.
 	 */
 	public static function sync_post_meta( $post_id, $post ) {
 		if ( ! self::is_listing( $post->post_type ) ) {
@@ -630,31 +632,53 @@ final class Newspack_Listings_Core {
 	}
 
 	/**
-	 * If using a Newspack theme, force single listings pages to use the wide template (sans widget sidebar).
+	 * If using a Newspack theme, respect the "default template" option setting in the Customizer.
 	 *
-	 * @param string $template File path of the template to use for the current single post.
-	 * @return string Filtered template file path.
+	 * @param string  $post_id Post ID.
+	 * @param object  $post Post object of the post being created or updated.
+	 * @param boolean $update Whether this is an existing post being updated.
 	 */
-	public static function set_default_template( $template ) {
+	public static function set_default_template( $post_id, $post, $update ) {
+		if ( ! $update && self::is_listing() ) {
+			$post_template_default = get_theme_mod( 'post_template_default', 'default' );
+
+			if ( 'default' !== $post_template_default ) {
+				update_post_meta( $post_id, '_wp_page_template', $post_template_default );
+			}
+		}
+	}
+
+	/**
+	 * If using the single-featured template, apply single-featured body class to listing posts
+	 * so that they inherit theme styles for that template. Default and wide templates don't
+	 * depend on a unique class for styling.
+	 *
+	 * @param array $classes Array of body class names.
+	 * @return array Filtered array of body classes.
+	 */
+	public static function set_template_class( $classes ) {
 		if ( self::is_listing() ) {
-			$wide_template = str_replace( 'single.php', 'single-wide.php', $template );
-
-			if ( file_exists( $wide_template ) ) {
-				$template = $wide_template;
-
-				// Add the single-wide CSS class to the body.
-				add_filter(
-					'body_class',
-					function( $classes ) {
-						$classes[] = 'post-template-single-wide';
-
-						return $classes;
-					}
-				);
+			$template = get_page_template_slug();
+			if ( 'single-feature.php' === $template ) {
+				$classes[] = 'post-template-single-feature';
 			}
 		}
 
-		return $template;
+		return $classes;
+	}
+
+	/**
+	 * If using a Newspack theme, add support for featured image options to all listings.
+	 *
+	 * @param array $post_types Array of supported post types.
+	 * @return array Filtered array of supported post types.
+	 */
+	public static function support_featured_image_options( $post_types ) {
+		if ( self::is_listing() ) {
+			$post_types = array_merge( $post_types, array_values( self::NEWSPACK_LISTINGS_POST_TYPES ) );
+		}
+
+		return $post_types;
 	}
 
 	/**

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -26,11 +26,50 @@ final class Newspack_Listings_Settings {
 	 * @return array Array of default settings.
 	 */
 	public static function get_default_settings() {
-		$defaults = [
-			'permalink_prefix' => __( 'listings', 'newspack-listings' ),
+		return [
+			[
+				'description' => __( 'The URL prefix for all listings. This prefix will appear before the listing slug in all listing URLs.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_permalink_prefix',
+				'label'       => __( 'Listings permalink prefix', 'newspack-listings' ),
+				'type'        => 'input',
+				'value'       => __( 'listings', 'newspack-listings' ),
+			],
+			[
+				'description' => __( 'The URL slug for event listings.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_event_slug',
+				'label'       => __( 'Event listings slug', 'newspack-listings' ),
+				'type'        => 'input',
+				'value'       => __( 'events', 'newspack-listings' ),
+			],
+			[
+				'description' => __( 'The URL slug for generic listings.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_generic_slug',
+				'label'       => __( 'Generic listings slug', 'newspack-listings' ),
+				'type'        => 'input',
+				'value'       => __( 'items', 'newspack-listings' ),
+			],
+			[
+				'description' => __( 'The URL slug for marketplace listings.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_marketplace_slug',
+				'label'       => __( 'Marketplace listings slug', 'newspack-listings' ),
+				'type'        => 'input',
+				'value'       => __( 'marketplace', 'newspack-listings' ),
+			],
+			[
+				'description' => __( 'The URL slug for place listings.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_place_slug',
+				'label'       => __( 'Place listings slug', 'newspack-listings' ),
+				'type'        => 'input',
+				'value'       => __( 'places', 'newspack-listings' ),
+			],
+			[
+				'description' => __( 'This setting can be overridden per listing.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_hide_author',
+				'label'       => __( 'Hide authors for new listings by default', 'newpack-listings' ),
+				'type'        => 'checkbox',
+				'value'       => true,
+			],
 		];
-
-		return $defaults;
 	}
 
 	/**
@@ -41,16 +80,22 @@ final class Newspack_Listings_Settings {
 	 */
 	public static function get_settings( $option = null ) {
 		$defaults = self::get_default_settings();
-		$settings = [
-			'permalink_prefix' => get_option( 'newspack_listings_permalink_prefix', $defaults['permalink_prefix'] ),
-		];
+		$settings = array_reduce(
+			$defaults,
+			function( $acc, $setting ) {
+				$key   = $setting['key'];
+				$value = get_option( $key, $setting['value'] );
 
-		// Guard against empty strings, which can happen if an option is set and then unset.
-		foreach ( $settings as $key => $value ) {
-			if ( empty( $value ) ) {
-				$settings[ $key ] = $defaults[ $key ];
-			}
-		}
+				// Guard against empty strings, which can happen if an option is set and then unset.
+				if ( '' === $value && 'checkbox' !== $setting['type'] ) {
+					$value = $setting['value'];
+				}
+
+				$acc[ $key ] = $value;
+				return $acc;
+			},
+			[]
+		);
 
 		// If passed an option key name, just give that option.
 		if ( ! empty( $option ) ) {
@@ -59,24 +104,6 @@ final class Newspack_Listings_Settings {
 
 		// Otherwise, return all settings.
 		return $settings;
-	}
-
-	/**
-	 * Get list of settings fields.
-	 *
-	 * @return array Settings list.
-	 */
-	public static function get_settings_list() {
-		$defaults = self::get_default_settings();
-
-		return [
-			[
-				'label' => __( 'Listings permalink prefix', 'newspack-listings' ),
-				'value' => $defaults['permalink_prefix'],
-				'key'   => 'newspack_listings_permalink_prefix',
-				'type'  => 'input',
-			],
-		];
 	}
 
 	/**
@@ -107,7 +134,7 @@ final class Newspack_Listings_Settings {
 			null,
 			'newspack-listings-settings-admin'
 		);
-		foreach ( self::get_settings_list() as $setting ) {
+		foreach ( self::get_default_settings() as $setting ) {
 			register_setting(
 				'newspack_listings_options_group',
 				$setting['key']
@@ -131,21 +158,28 @@ final class Newspack_Listings_Settings {
 	public static function newspack_listings_settings_callback( $setting ) {
 		$key   = $setting['key'];
 		$type  = $setting['type'];
-		$value = ( ! empty( get_option( $key, false ) ) ) ? get_option( $key, false ) : $setting['value'];
+		$value = get_option( $key, $setting['value'] );
 
-		if ( 'textarea' === $type ) {
+		if ( 'checkbox' === $type ) {
 			printf(
-				'<textarea id="%s" name="%s" class="widefat" rows="4">%s</textarea>',
+				'<input type="checkbox" id="%s" name="%s" %s /><p class="description" for="%s">%s</p>',
 				esc_attr( $key ),
 				esc_attr( $key ),
-				esc_attr( $value )
+				! empty( $value ) ? 'checked' : '',
+				esc_attr( $key ),
+				esc_html( $setting['description'] )
 			);
 		} else {
+			if ( empty( $value ) ) {
+				$value = $setting['value'];
+			}
 			printf(
-				'<input type="text" id="%s" name="%s" value="%s" class="widefat" />',
+				'<input type="text" id="%s" name="%s" value="%s" class="regular-text" /><p class="description" for="%s">%s</p>',
 				esc_attr( $key ),
 				esc_attr( $key ),
-				esc_attr( $value )
+				esc_attr( $value ),
+				esc_attr( $key ),
+				esc_html( $setting['description'] )
 			);
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A number of smaller features and quality-of-life improvements that make use of existing Newspack theme features:

* Enables selection of templates for listing posts (and respects the default post template Customizer setting from the theme): this may be a breaking change for existing listings because previously, all listings used the `single-wide` template. After this change, all existing listings will use the default post template set in Customizer, unless the setting is changed per listing post.
* Enables featured image style, and respects the default image style set in Customizer (closes #28)
* Adds several new sitewide settings to the Newspack Listings settings page:
  - URL slugs for each listing type (closes #41)
  - Hide author info by default for new listings: this new setting is ON by default, meaning the author byline and bio

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
