### PR TITLE
feat: new global setting and post option to hide publish dates

### DIFF
--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -72,6 +72,7 @@ final class Newspack_Listings_Core {
 		add_filter( 'body_class', [ __CLASS__, 'set_template_class' ] );
 		add_action( 'save_post', [ __CLASS__, 'sync_post_meta' ], 10, 2 );
 		add_filter( 'newspack_listings_hide_author', [ __CLASS__, 'hide_author' ] );
+		add_filter( 'newspack_listings_hide_publish_date', [ __CLASS__, 'hide_publish_date' ] );
 		add_filter( 'newspack_theme_featured_image_post_types', [ __CLASS__, 'support_featured_image_options' ] );
 		register_activation_hook( NEWSPACK_LISTINGS_FILE, [ __CLASS__, 'activation_hook' ] );
 	}
@@ -267,7 +268,7 @@ final class Newspack_Listings_Core {
 		}
 
 		$all_meta_fields = [
-			'newspack_listings_contact_email'    => [
+			'newspack_listings_contact_email'     => [
 				'post_types' => [
 					self::NEWSPACK_LISTINGS_POST_TYPES['event'],
 					self::NEWSPACK_LISTINGS_POST_TYPES['generic'],
@@ -299,7 +300,7 @@ final class Newspack_Listings_Core {
 					},
 				],
 			],
-			'newspack_listings_contact_phone'    => [
+			'newspack_listings_contact_phone'     => [
 				'post_types' => [
 					self::NEWSPACK_LISTINGS_POST_TYPES['event'],
 					self::NEWSPACK_LISTINGS_POST_TYPES['generic'],
@@ -331,7 +332,7 @@ final class Newspack_Listings_Core {
 					},
 				],
 			],
-			'newspack_listings_contact_address'  => [
+			'newspack_listings_contact_address'   => [
 				'post_types' => [
 					self::NEWSPACK_LISTINGS_POST_TYPES['event'],
 					self::NEWSPACK_LISTINGS_POST_TYPES['generic'],
@@ -380,7 +381,7 @@ final class Newspack_Listings_Core {
 					],
 				],
 			],
-			'newspack_listings_business_hours'   => [
+			'newspack_listings_business_hours'    => [
 				'post_types' => [
 					self::NEWSPACK_LISTINGS_POST_TYPES['event'],
 					self::NEWSPACK_LISTINGS_POST_TYPES['marketplace'],
@@ -427,7 +428,7 @@ final class Newspack_Listings_Core {
 					],
 				],
 			],
-			'newspack_listings_locations'        => [
+			'newspack_listings_locations'         => [
 				'post_types' => [
 					self::NEWSPACK_LISTINGS_POST_TYPES['event'],
 					self::NEWSPACK_LISTINGS_POST_TYPES['generic'],
@@ -484,7 +485,7 @@ final class Newspack_Listings_Core {
 					},
 				],
 			],
-			'newspack_listings_event_start_date' => [
+			'newspack_listings_event_start_date'  => [
 				'post_types' => [
 					self::NEWSPACK_LISTINGS_POST_TYPES['event'],
 				],
@@ -507,7 +508,7 @@ final class Newspack_Listings_Core {
 					},
 				],
 			],
-			'newspack_listings_price'            => [
+			'newspack_listings_price'             => [
 				'post_types' => [
 					self::NEWSPACK_LISTINGS_POST_TYPES['marketplace'],
 				],
@@ -530,7 +531,7 @@ final class Newspack_Listings_Core {
 					},
 				],
 			],
-			'newspack_listings_hide_author'      => [
+			'newspack_listings_hide_author'       => [
 				'post_types' => [
 					self::NEWSPACK_LISTINGS_POST_TYPES['event'],
 					self::NEWSPACK_LISTINGS_POST_TYPES['generic'],
@@ -551,7 +552,28 @@ final class Newspack_Listings_Core {
 					},
 				],
 			],
-			'newspack_listings_hide_parents'     => [
+			'newspack_listings_hide_publish_date' => [
+				'post_types' => [
+					self::NEWSPACK_LISTINGS_POST_TYPES['event'],
+					self::NEWSPACK_LISTINGS_POST_TYPES['generic'],
+					self::NEWSPACK_LISTINGS_POST_TYPES['marketplace'],
+					self::NEWSPACK_LISTINGS_POST_TYPES['place'],
+				],
+				'label'      => __( 'Hide publish date', 'newspack-listings' ),
+				'settings'   => [
+					'object_subtype'    => $post_type,
+					'default'           => boolval( Settings::get_settings( 'newspack_listings_hide_publish_date' ) ), // Configurable in plugin-wide settings.
+					'description'       => __( 'Hide publish and updated dates for this listing', 'newspack-listings' ),
+					'type'              => 'boolean',
+					'sanitize_callback' => 'rest_sanitize_boolean',
+					'single'            => true,
+					'show_in_rest'      => true,
+					'auth_callback'     => function() {
+						return current_user_can( 'edit_posts' );
+					},
+				],
+			],
+			'newspack_listings_hide_parents'      => [
 				'post_types' => [
 					'page',
 					'post',
@@ -574,7 +596,7 @@ final class Newspack_Listings_Core {
 					},
 				],
 			],
-			'newspack_listings_hide_children'    => [
+			'newspack_listings_hide_children'     => [
 				'post_types' => [
 					'page',
 					'post',
@@ -699,6 +721,23 @@ final class Newspack_Listings_Core {
 		}
 
 		return $hide_author;
+	}
+
+	/**
+	 * Filter callback to decide whether to show the publish and updated dates for the current singular post.
+	 * Can be used from other plugins and/or themes to modify default template behavior.
+	 *
+	 * @param boolean $hide_publish_dates Whether or not to hide the publish and updated dates.
+	 * @return boolean If the current post a.) is a listing and b.) has enabled the option to hide publish and updated dates.
+	 */
+	public static function hide_publish_date( $hide_publish_dates = false ) {
+		$post_id = get_the_ID();
+
+		if ( self::is_listing() && ! empty( get_post_meta( $post_id, 'newspack_listings_hide_publish_date', true ) ) ) {
+			return true;
+		}
+
+		return $hide_publish_dates;
 	}
 
 	/**

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -72,6 +72,13 @@ final class Newspack_Listings_Settings {
 				'value'       => true,
 			],
 			[
+				'description' => __( 'This setting can be overridden per listing.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_hide_publish_date',
+				'label'       => __( 'Hide publish and updated dates for listings by default', 'newpack-listings' ),
+				'type'        => 'checkbox',
+				'value'       => true,
+			],
+			[
 				'description' => __( 'This setting can be overridden per listing, post, or page.', 'newspack-listings' ),
 				'key'         => 'newspack_listings_hide_parents',
 				'label'       => __( 'Hide parent listings by default', 'newpack-listings' ),

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -15,7 +15,7 @@ import './style.scss';
 
 const SidebarComponent = ( { meta, updateMetaValue } ) => {
 	const { post_type_label: postTypeLabel, post_types: postTypes } = window.newspack_listings_data;
-	const { newspack_listings_hide_author } = meta;
+	const { newspack_listings_hide_author, newspack_listings_hide_publish_date } = meta;
 
 	if ( ! postTypes ) {
 		return null;
@@ -30,20 +30,40 @@ const SidebarComponent = ( { meta, updateMetaValue } ) => {
 				isListing() ? postTypeLabel : __( 'Newspack Listings', 'newspack-listings' )
 			) }
 		>
+			<p>
+				<em>
+					{ __( 'Overrides ', 'newspack-listings' ) }
+					<ExternalLink href="/wp-admin/admin.php?page=newspack-listings-settings-admin">
+						{ __( 'global settings', 'newspack-listings' ) }
+					</ExternalLink>
+				</em>
+			</p>
 			<PanelRow>
 				<ToggleControl
 					className={ 'newspack-listings__toggle-control' }
 					label={ __( 'Hide listing author', 'newspack-listings' ) }
-					help={ () => (
-						<p>
-							{ __( 'Overrides ', 'newspack-listings' ) }
-							<ExternalLink href="/wp-admin/admin.php?page=newspack-listings-settings-admin">
-								{ __( 'global settings', 'newspack-listings' ) }
-							</ExternalLink>
-						</p>
+					help={ sprintf(
+						__( '%s the author byline for this listing.', 'newspack-listings' ),
+						newspack_listings_hide_author
+							? __( 'Hide', 'newspack-listings' )
+							: __( 'Show', 'newspack-listings' )
 					) }
 					checked={ newspack_listings_hide_author }
 					onChange={ value => updateMetaValue( 'newspack_listings_hide_author', value ) }
+				/>
+			</PanelRow>
+			<PanelRow>
+				<ToggleControl
+					className={ 'newspack-listings__toggle-control' }
+					label={ __( 'Hide publish date', 'newspack-listings' ) }
+					help={ sprintf(
+						__( '%s the publish and updated dates for this listing.', 'newspack-listings' ),
+						newspack_listings_hide_publish_date
+							? __( 'Hide', 'newspack-listings' )
+							: __( 'Show', 'newspack-listings' )
+					) }
+					checked={ newspack_listings_hide_publish_date }
+					onChange={ value => updateMetaValue( 'newspack_listings_hide_publish_date', value ) }
 				/>
 			</PanelRow>
 		</PluginDocumentSettingPanel>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a new global setting and post-level option to hide the publish (and modified, if enabled in the theme) dates from listings. Addresses publisher feedback that this should be a feature alongside the ability to show/hide authors.

* Requires https://github.com/Automattic/newspack-theme/pull/1359 in the theme to test template-level changes
* Requires https://github.com/Automattic/newspack-blocks/pull/762 to test with Homepage Posts and Post Carousel blocks (also fixes the display of listing authors if the "Hide authors" option is on)

Closes #55.

### How to test the changes in this Pull Request:

1. Check out the required theme and blocks branches mentioned above, along with this branch.
2. From WP admin, visit Listings > Settings and confirm a new global setting which is on by default:

<img width="537" alt="Screen Shot 2021-05-24 at 11 23 18 AM" src="https://user-images.githubusercontent.com/2230142/119384792-7636b800-bc82-11eb-9796-e0259bfb4b06.png">

3. Without changing the setting, visit any published listing's singular page. Confirm that the publish and modified dates are not shown under the title.
4. Edit the listing, expand the "[LISTING TYPE] Settings" sidebar panel. Confirm that there's a new option to hide publish date, which is on by default (matching the global setting):

<img width="273" alt="Screen Shot 2021-05-24 at 11 25 02 AM" src="https://user-images.githubusercontent.com/2230142/119384963-b26a1880-bc82-11eb-8ca3-6b34bcb2d0bf.png">

5. Turn off the option for the post, refresh on the front-end, confirm that the dates are now shown.
6. Turn off the option in global settings. Confirm the following:
  - For the listing you were editing, things are unchanged (because you manually turned off the option in the post editor).
  - For a second listing, the post-level option is off, matching global settings, and the dates are shown on the front-end.
  - For that second listing, if you turn the post-level option, on the dates are no longer shown.
8. On another post or page, add a Homepage Posts block. Set the post type to the listings you were editing, and ensure that they're shown in the Homepage Posts block.
9. Confirm that the publish/modified dates and author names are or aren't shown according to each individual post's setting, in both the editor and on the front-end.
10. Confirm that publish/modified dates and author names for other listings for which you haven't edited their individual settings, the publish/modified dates are or aren't shown according to the global setting, in both the editor and on the front-end.
11. Repeat steps 8-10 with a Post Carousel block.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
