### PR TITLE
test: init test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,24 +20,54 @@ jobs:
           root: ~/
           paths:
             - project
-
-  # Linting
-  lint:
+  lint-js-scss:
     docker:
       - image: circleci/php:7.2-node-browsers
     steps:
       - checkout_with_workspace
       - run:
-          name: Run SCSS Linter
-          command: npm run lint:js
+          name: Run Linter
+          command: npm run lint
+
+  test-php:
+    docker:
+      - image: circleci/php:7.2
+      - image: circleci/mysql:5.6.50
+    environment:
+      - WP_TESTS_DIR: '/tmp/wordpress-tests-lib'
+      - WP_CORE_DIR: '/tmp/wordpress/'
+    steps:
+      - checkout
       - run:
-          name: Run JS Linter
-          command: npm run lint:js
+          name: Setup Environment Variables
+          command: |
+            echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
+            source /home/circleci/.bashrc
       - run:
-          name: Run PHP Linter
+          name: Install Dependencies
+          command: |
+            sudo apt-get update && sudo apt-get install subversion
+            sudo -E docker-php-ext-install mysqli
+            sudo apt-get update && sudo apt-get install default-mysql-client
+      - run:
+          name: Run Tests
           command: |
             composer install
-            npm run lint:php
+            composer global require "phpunit/phpunit=5.7.*"
+            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+            phpunit
+
+  lint-php:
+    docker:
+      - image: circleci/php:7.2
+    steps:
+      - checkout
+      - run:
+          name: Lint PHP Files
+          command: |
+            composer install
+            ./vendor/bin/phpcs
 
   # Release job
   release:
@@ -71,10 +101,12 @@ jobs:
 
 workflows:
   version: 2
-  main:
+  all:
     jobs:
+      - test-php
       - build
-      - lint:
+      - lint-php
+      - lint-js-scss:
           requires:
             - build
       - release:

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+	WP_BRANCH=${WP_VERSION%\-*}
+	WP_TESTS_TAG="branches/$WP_BRANCH"
+
+elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p $TMPDIR/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  $TMPDIR/wordpress-nightly/wordpress-nightly.zip
+		unzip -q $TMPDIR/wordpress-nightly/wordpress-nightly.zip -d $TMPDIR/wordpress-nightly/
+		mv $TMPDIR/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i.bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --ignore-externals --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --ignore-externals --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/includes/class-newspack-listings-blocks.php
+++ b/includes/class-newspack-listings-blocks.php
@@ -133,24 +133,35 @@ final class Newspack_Listings_Blocks {
 			}
 			$type = $block_directory->getFilename();
 
-			/* If view.php is found, include it and use for block rendering. */
+			// If view.php is found, include it and use for block rendering.
 			$view_php_path = $src_directory . $type . '/view.php';
 			if ( file_exists( $view_php_path ) ) {
 				include_once $view_php_path;
 				continue;
 			}
 
-			/* If view.php is missing but view Javascript file is found, do generic view asset loading. */
+			// If block.json exists, use it to register the block with default attributes.
+			$block_config_file        = $src_directory . $type . '/block.json';
+			$block_name               = "newspack-listings/{$type}";
+			$block_default_attributes = null;
+			if ( file_exists( $block_config_file ) ) {
+				$block_config             = json_decode( file_get_contents( $block_config_file ), true ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+				$block_name               = $block_config['name'];
+				$block_default_attributes = $block_config['attributes'];
+			}
+
+			// If view.php is missing but view Javascript file is found, do generic view asset loading.
 			$view_js_path = $dist_directory . $type . '/view.js';
 			if ( file_exists( $view_js_path ) ) {
 				register_block_type(
-					"newspack-listings/{$type}",
-					array(
+					$block_name,
+					[
 						'render_callback' => function( $attributes, $content ) use ( $type ) {
 							Newspack_Blocks::enqueue_view_assets( $type );
 							return $content;
 						},
-					)
+						'attributes'      => $block_default_attributes,
+					]
 				);
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "eslint --ext .js,.jsx src",
     "lint:scss": "stylelint \"**/*.scss\" --syntax scss",
-    "lint:php": "./vendor/bin/phpcs .",
     "format:js": "prettier 'src/**/*.{js,jsx}' --write",
     "format:scss": "prettier --write 'src/**/*.scss'",
     "format:php": "./vendor/bin/phpcbf .",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory>./includes</directory>
+			<directory>./api</directory>
+		</whitelist>
+	</filter>
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * PHPUnit bootstrap file
+ *
+ * @package Newspack_Listings
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore
+	exit( 1 );
+}
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually load the plugin being tested.
+ */
+function _manually_load_plugin() {
+	$_SERVER['HTTP_REFERER'] = 'https://' . $_SERVER['HTTP_HOST']; // phpcs:ignore
+	$_SERVER['HTTP_USER_AGENT'] = 'Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/89.0.4389.90 Safari\/537.36'; // phpcs:ignore
+
+	require dirname( dirname( __FILE__ ) ) . '/newspack-listings.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+define( 'IS_TEST_ENV', 1 );
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-blocks.php
+++ b/tests/test-blocks.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Class Blocks Test
+ *
+ * @package Newspack_Listings
+ */
+
+use \Newspack_Listings\Newspack_Listings_Core as Core;
+use \Newspack_Listings\Utils as Utils;
+
+/**
+ * Blocks test case.
+ */
+class BlocksTest extends WP_UnitTestCase {
+	private static $listings           = []; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	private static $default_attributes = []; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+
+	public function setUp() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		// Remove any listings (from previous tests).
+		foreach ( self::$listings as $listing_id ) {
+			wp_delete_post( $listing_id );
+		}
+
+		// Set default block options for Curated List.
+		$block_json = json_decode(
+			file_get_contents( NEWSPACK_LISTINGS_PLUGIN_FILE . '/src/blocks/curated-list/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			true
+		);
+		foreach ( $block_json['attributes'] as $attribute => $options ) {
+			self::$default_attributes[ $attribute ] = $options['default'];
+		}
+	}
+
+	/**
+	 * Create a listing.
+	 *
+	 * @param string $type Listing type.
+	 */
+	private function create_listing( $type = 'place' ) {
+		$listing_id = self::factory()->post->create(
+			[
+				'post_type'    => Core::NEWSPACK_LISTINGS_POST_TYPES[ $type ],
+				'post_title'   => 'Listing Title: ' . $type,
+				'post_content' => 'Some ' . $type . ' listing content',
+			]
+		);
+
+		self::$listings[] = $listing_id;
+		return $listing_id;
+	}
+
+	/**
+	 * Basic Block rendering - Single Prompt block.
+	 */
+	public function test_curated_list_block_query_types() {
+		$place = self::create_listing( 'place' );
+		$event = self::create_listing( 'event' );
+
+		// Curated List: query mode with all listing types.
+		$query_all_block_content = Newspack_Listings\Curated_List_Block\render_block(
+			wp_parse_args(
+				[
+					'queryMode'       => true,
+					'queriedListings' => self::$listings,
+				],
+				self::$default_attributes
+			),
+			''
+		);
+
+		self::assertContains(
+			get_the_title( $place ),
+			$query_all_block_content,
+			'Query block with type set to all contains the place listing.'
+		);
+
+		self::assertContains(
+			get_the_title( $event ),
+			$query_all_block_content,
+			'Query block with type set to all contains the event listing.'
+		);
+
+		// Curated List: query mode with only Place listings.
+		$query_place_block_content = Newspack_Listings\Curated_List_Block\render_block(
+			wp_parse_args(
+				[
+					'queryMode'       => true,
+					'queryOptions'    => [
+						'type'               => Core::NEWSPACK_LISTINGS_POST_TYPES['place'],
+						'authors'            => [],
+						'categories'         => [],
+						'tags'               => [],
+						'categoryExclusions' => [],
+						'tagExclusions'      => [],
+						'maxItems'           => 10,
+						'sortBy'             => 'date',
+						'order'              => 'DESC',
+					],
+					'queriedListings' => self::$listings,
+				],
+				self::$default_attributes
+			),
+			''
+		);
+
+		self::assertContains(
+			get_the_title( $place ),
+			$query_place_block_content,
+			'Query block with type set to "place" contains the place listing.'
+		);
+
+		self::assertNotContains(
+			get_the_title( $event ),
+			$query_place_block_content,
+			'Query block with type set to "place" does not contain the event listing.'
+		);
+	}
+}

--- a/tests/test-blocks.php
+++ b/tests/test-blocks.php
@@ -50,7 +50,7 @@ class BlocksTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Basic Block rendering - Single Prompt block.
+	 * Basic Block rendering - Curated List block.
 	 */
 	public function test_curated_list_block_query_types() {
 		$place = self::create_listing( 'place' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a PHP test suite and hooks it up to CI for this repo. For now, it includes only some basic block rendering tests for the Curated List block, but this should lay the foundation for a more robust testing suite for other features as needed.

Closes #52.

### How to test the changes in this Pull Request:

Observe the tests and linters passing below.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
