### PR TITLE
fix: use value property of selection from AutocompleteWithSuggestions

### DIFF
--- a/src/blocks/listing/block.json
+++ b/src/blocks/listing/block.json
@@ -7,8 +7,8 @@
       "default": ""
     },
     "listing": {
-      "type": "number",
-      "default": 0
+      "type": "string",
+      "default": ""
     },
     "locations": {
       "type": "array",

--- a/src/blocks/listing/block.json
+++ b/src/blocks/listing/block.json
@@ -7,8 +7,8 @@
       "default": ""
     },
     "listing": {
-      "type": "string",
-      "default": ""
+      "type": "number",
+      "default": 0
     },
     "locations": {
       "type": "array",

--- a/src/blocks/listing/edit.js
+++ b/src/blocks/listing/edit.js
@@ -157,7 +157,7 @@ const ListingEditorComponent = ( {
 						if ( _listing.length ) {
 							setIsEditingPost( false );
 							setPost( null );
-							setAttributes( { listing: parseInt( _listing.shift().value ) } );
+							setAttributes( { listing: _listing.shift().value.toString() } );
 						}
 					} }
 					selectedPost={ isEditingPost ? null : listing }

--- a/src/blocks/listing/edit.js
+++ b/src/blocks/listing/edit.js
@@ -157,7 +157,7 @@ const ListingEditorComponent = ( {
 						if ( _listing.length ) {
 							setIsEditingPost( false );
 							setPost( null );
-							setAttributes( { listing: _listing.shift().value } );
+							setAttributes( { listing: parseInt( _listing.shift().value ) } );
 						}
 					} }
 					selectedPost={ isEditingPost ? null : listing }

--- a/src/blocks/listing/edit.js
+++ b/src/blocks/listing/edit.js
@@ -157,7 +157,7 @@ const ListingEditorComponent = ( {
 						if ( _listing.length ) {
 							setIsEditingPost( false );
 							setPost( null );
-							setAttributes( { listing: _listing[ 0 ] } );
+							setAttributes( { listing: _listing.shift().value } );
 						}
 					} }
 					selectedPost={ isEditingPost ? null : listing }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug introduced by #56 which broke Specific Listings mode in the Curated List block.

### How to test the changes in this Pull Request:

1. On `epic/phase-2`, create a Curated List block in Specific Listings mode and add a listing of any type.
2. Observe that no matter what listing you select, the block preview displays the latest published listing of any type (not necessarily matching the selected type).
3. Observe on the front-end that the list block shows no content.
4. Check out this branch, confirm that both issues with selecting and showing specific listings are fixed in both the editor and on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
