### PR TITLE
fix: syncing attributes to inner blocks

### DIFF
--- a/src/blocks/curated-list/edit.js
+++ b/src/blocks/curated-list/edit.js
@@ -274,6 +274,19 @@ const CuratedListEditorComponent = ( {
 	}, [ selectedBlock ]);
 
 	/**
+	 * If in specific listings mode, sync parent attributes to inner blocks.
+	 */
+	useEffect(() => {
+		if ( list && list.innerBlocks ) {
+			updateBlockAttributes(
+				[ list.clientId ].concat( list.innerBlocks.map( innerBlock => innerBlock.clientId ) ), // Array of client IDs for both list container and individual listings.
+				attributes,
+				false
+			);
+		}
+	}, [ JSON.stringify( attributes ) ]);
+
+	/**
 	 * Determine if the background color is dark or light.
 	 */
 	useEffect(() => {

--- a/src/blocks/curated-list/edit.js
+++ b/src/blocks/curated-list/edit.js
@@ -274,10 +274,10 @@ const CuratedListEditorComponent = ( {
 	}, [ selectedBlock ]);
 
 	/**
-	 * If in specific listings mode, sync parent attributes to inner blocks.
+	 * Sync parent attributes to inner blocks.
 	 */
 	useEffect(() => {
-		if ( list && list.innerBlocks ) {
+		if ( list ) {
 			updateBlockAttributes(
 				[ list.clientId ].concat( list.innerBlocks.map( innerBlock => innerBlock.clientId ) ), // Array of client IDs for both list container and individual listings.
 				attributes,

--- a/src/blocks/list-container/edit.js
+++ b/src/blocks/list-container/edit.js
@@ -6,17 +6,11 @@ import { InnerBlocks, InspectorControls } from '@wordpress/block-editor';
 import { Notice, PanelRow, Spinner } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
 
-const ListContainerEditorComponent = ( { clientId, innerBlocks, parent, setAttributes } ) => {
+const ListContainerEditorComponent = ( { clientId, innerBlocks, parent } ) => {
 	const parentAttributes = parent.attributes || {};
 	const { queryMode, queryOptions, showSortUi } = parentAttributes;
 	const { order } = queryOptions;
-
-	// Sync parent attributes to list container attributes, so that we can use parent attributes in the PHP render callback.
-	useEffect(() => {
-		setAttributes( { ...parentAttributes } );
-	}, [ JSON.stringify( parentAttributes ) ]);
 
 	if ( queryMode && ! showSortUi ) {
 		return null;

--- a/src/blocks/listing/edit.js
+++ b/src/blocks/listing/edit.js
@@ -36,8 +36,6 @@ const ListingEditorComponent = ( {
 
 		if ( 'newspack-listings/list-container' === blockInfo.name ) {
 			acc.listContainer = blockInfo;
-		} else if ( 'newspack-listings/curated-list' === blockInfo.name ) {
-			acc.curatedList = blockInfo;
 		}
 
 		return acc;
@@ -58,15 +56,10 @@ const ListingEditorComponent = ( {
 
 	// Fetch listing post data if we have a listing post ID.
 	useEffect(() => {
-		if ( listing ) {
+		if ( ! post && listing ) {
 			fetchPost( listing );
 		}
 	}, [ listing ]);
-
-	// Sync parent attributes to listing attributes, so that we can use parent attributes in the PHP render callback.
-	useEffect(() => {
-		setAttributes( { ...parent.curatedList.attributes } );
-	}, [ JSON.stringify( parent.curatedList.attributes ) ]);
 
 	// Fetch listing post by listingId.
 	const fetchPost = async listingId => {
@@ -188,7 +181,7 @@ const ListingEditorComponent = ( {
 
 		return (
 			<div className="newspack-listings__listing-editor newspack-listings__listing">
-				<Listing attributes={ parent.curatedList.attributes } error={ error } post={ post } />
+				<Listing attributes={ attributes } error={ error } post={ post } />
 				{ post && (
 					<Button
 						isLink


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Something must have changed in a recent Gutenberg release that broke the (admittedly hacky) method we were using to sync the parent Curated List block's attributes to its inner blocks. This PR updates the method to use `updateBlockAttributes` [as documented](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-block-editor/#updateBlockAttributes) for this purpose instead.

Closes #62.

### How to test the changes in this Pull Request:

1. On `master` or `epic/phase-2`, create a Curated List block and set to Specific Listings mode.
2. Add several listings of any type.
3. Select the Curated List container block and change its content-related attributes, especially "Show Excerpt", "Show Category", "Show Tags", "Show Featured Image", etc.
4. Observe that the individual listings do not update to reflect the selected options.
5. Check out this branch, repeat step 3, and this time confirm that the editor preview updates as expected and the listings are shown with the expected content on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
