### PR TITLE
feat: support Newspack Sponsors for listings

### DIFF
--- a/includes/class-newspack-listings-api.php
+++ b/includes/class-newspack-listings-api.php
@@ -333,11 +333,6 @@ final class Newspack_Listings_Api {
 							$item['tags'] = get_the_terms( $post->ID, 'post_tag' );
 						}
 
-						// If $fields includes author and the post isn't set to hide author, get the post author.
-						if ( in_array( 'author', $fields ) && empty( get_post_meta( $post->ID, 'newspack_listings_hide_author', true ) ) ) {
-							$item['author'] = get_the_author_meta( 'display_name', $post->post_author );
-						}
-
 						// If $fields includes excerpt, get the post excerpt.
 						if ( in_array( 'excerpt', $fields ) ) {
 							$item['excerpt'] = Utils\get_listing_excerpt( $post );
@@ -352,11 +347,21 @@ final class Newspack_Listings_Api {
 						}
 
 						// If $fields includes meta, get all Newspack Listings meta fields.
-						if ( in_array( 'meta', $fields ) ) {
-							$post_meta = Core::get_meta_values( $post->ID, $post->post_type );
+						// Append sponsors and author info to this field so we can avoid having to register custom REST fields.
+						if ( in_array( 'meta', $fields ) || in_array( 'author', $fields ) ) {
+							$item['meta'] = [];
+							$post_meta    = Core::get_meta_values( $post->ID, $post->post_type );
 
 							if ( ! empty( $post_meta ) ) {
 								$item['meta'] = $post_meta;
+							}
+
+							// Include sponsors info.
+							$item['meta']['sponsors'] = Utils\get_sponsors( $post->ID, 'native' );
+
+							// If $fields includes author and the post isn't set to hide author, get the post author.
+							if ( in_array( 'author', $fields ) && empty( get_post_meta( $post->ID, 'newspack_listings_hide_author', true ) ) ) {
+								$item['meta']['author'] = get_the_author_meta( 'display_name', $post->post_author );
 							}
 						}
 

--- a/includes/class-newspack-listings-api.php
+++ b/includes/class-newspack-listings-api.php
@@ -70,16 +70,16 @@ final class Newspack_Listings_Api {
 					'callback'            => [ __CLASS__, 'get_items' ],
 					'args'                => [
 						'query'      => [
-							'sanitize_callback' => 'Utils\sanitize_array',
+							'sanitize_callback' => '\Newspack_Listings\Utils\sanitize_array',
 						],
 						'id'         => [
 							'sanitize_callback' => 'absint',
 						],
 						'type'       => [
-							'sanitize_callback' => 'Utils\sanitize_array',
+							'sanitize_callback' => '\Newspack_Listings\Utils\sanitize_array',
 						],
 						'attributes' => [
-							'sanitize_callback' => 'Utils\sanitize_array',
+							'sanitize_callback' => '\Newspack_Listings\Utils\sanitize_array',
 						],
 						'offset'     => [
 							'sanitize_callback' => 'absint',
@@ -290,7 +290,7 @@ final class Newspack_Listings_Api {
 	 * @return WP_REST_Response.
 	 */
 	public static function get_items( $request ) {
-		$listings   = [];
+		$response   = [];
 		$params     = $request->get_params();
 		$fields     = explode( ',', $params['_fields'] );
 		$search     = ! empty( $params['search'] ) ? $params['search'] : null;
@@ -414,6 +414,8 @@ final class Newspack_Listings_Api {
 				$listings_query->posts
 			);
 
+			$response = new \WP_REST_Response( $listings );
+
 			// Provide next URL if there are more pages.
 			if ( $next_page <= $listings_query->max_num_pages ) {
 				$next_url = add_query_arg(
@@ -433,7 +435,6 @@ final class Newspack_Listings_Api {
 			}
 		}
 
-		$response = new \WP_REST_Response( $listings );
 		return rest_ensure_response( $response );
 	}
 

--- a/includes/class-newspack-listings-api.php
+++ b/includes/class-newspack-listings-api.php
@@ -21,6 +21,12 @@ defined( 'ABSPATH' ) || exit;
  * Sets up API endpoints and handlers for listings.
  */
 final class Newspack_Listings_Api {
+	/**
+	 * REST route namespace.
+	 *
+	 * @var Newspack_Listings_Api
+	 */
+	protected static $namespace = 'newspack-listings/v1';
 
 	/**
 	 * The single instance of the class.
@@ -56,12 +62,42 @@ final class Newspack_Listings_Api {
 
 		// GET listings posts by ID, query args, or title search term.
 		register_rest_route(
-			'newspack-listings/v1',
+			self::$namespace,
 			'listings',
 			[
 				[
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => [ __CLASS__, 'get_items' ],
+					'args'                => [
+						'query'      => [
+							'sanitize_callback' => 'Utils\sanitize_array',
+						],
+						'id'         => [
+							'sanitize_callback' => 'absint',
+						],
+						'type'       => [
+							'sanitize_callback' => 'Utils\sanitize_array',
+						],
+						'attributes' => [
+							'sanitize_callback' => 'Utils\sanitize_array',
+						],
+						'offset'     => [
+							'sanitize_callback' => 'absint',
+						],
+						'page'       => [
+							'sanitize_callback' => 'absint',
+						],
+						'per_page'   => [
+							'sanitize_callback' => 'absint',
+						],
+						'search'     => [
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'_fields'    => [
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+
+					],
 					'permission_callback' => '__return_true',
 				],
 			]
@@ -69,7 +105,7 @@ final class Newspack_Listings_Api {
 
 		// GET listings taxonomy terms by name search term.
 		register_rest_route(
-			'newspack-listings/v1',
+			self::$namespace,
 			'terms',
 			[
 				[
@@ -82,7 +118,7 @@ final class Newspack_Listings_Api {
 
 		// GET listings taxonomy terms by name search term.
 		register_rest_route(
-			'newspack-listings/v1',
+			self::$namespace,
 			'children',
 			[
 				[
@@ -95,7 +131,7 @@ final class Newspack_Listings_Api {
 
 		// Set listings taxonomy terms.
 		register_rest_route(
-			'newspack-listings/v1',
+			self::$namespace,
 			'children',
 			[
 				[
@@ -254,6 +290,7 @@ final class Newspack_Listings_Api {
 	 * @return WP_REST_Response.
 	 */
 	public static function get_items( $request ) {
+		$listings   = [];
 		$params     = $request->get_params();
 		$fields     = explode( ',', $params['_fields'] );
 		$search     = ! empty( $params['search'] ) ? $params['search'] : null;
@@ -297,84 +334,84 @@ final class Newspack_Listings_Api {
 		$listings_query = new \WP_Query( $args );
 
 		if ( $listings_query->have_posts() ) {
-			$response = new \WP_REST_Response(
-				array_map(
-					function( $post ) use ( $attributes, $fields, $is_amp, $next_page, $query ) {
-						$item = [
-							'id'    => $post->ID,
-							'title' => $post->post_title,
+			$listings = array_map(
+				function( $post ) use ( $attributes, $fields, $is_amp, $next_page, $query ) {
+					$item = [
+						'id'    => $post->ID,
+						'title' => $post->post_title,
+					];
+
+					// if $fields includes html, get rendered HTML for the post.
+					if ( in_array( 'html', $fields ) && ! empty( $attributes ) ) {
+						$html = Utils\template_include(
+							'listing',
+							[
+								'attributes' => $attributes,
+								'post'       => $post,
+							]
+						);
+
+						// If an AMP page, convert to valid AMP HTML.
+						if ( $is_amp ) {
+							$html = Utils\generate_amp_partial( $html );
+						}
+
+						$item['html'] = $html;
+					}
+
+					// If $fields includes category, get the post categories.
+					if ( in_array( 'category', $fields ) ) {
+						$item['category'] = get_the_terms( $post->ID, 'category' );
+					}
+
+					// If $fields includes tags, get the post tags.
+					if ( in_array( 'tags', $fields ) ) {
+						$item['tags'] = get_the_terms( $post->ID, 'post_tag' );
+					}
+
+					// If $fields includes excerpt, get the post excerpt.
+					if ( in_array( 'excerpt', $fields ) ) {
+						$item['excerpt'] = Utils\get_listing_excerpt( $post );
+					}
+
+					// If $fields includes media, get the featured image + caption.
+					if ( in_array( 'media', $fields ) ) {
+						$item['media'] = [
+							'image'   => get_the_post_thumbnail_url( $post->ID, 'medium' ),
+							'caption' => get_the_post_thumbnail_caption( $post->ID ),
 						];
+					}
 
-						// if $fields includes html, get rendered HTML for the post.
-						if ( in_array( 'html', $fields ) && ! empty( $attributes ) ) {
-							$html = Utils\template_include(
-								'listing',
-								[
-									'attributes' => $attributes,
-									'post'       => $post,
-								]
-							);
+					// If $fields includes meta, get all Newspack Listings meta fields.
+					if ( in_array( 'meta', $fields ) || in_array( 'author', $fields ) ) {
+						$item['meta'] = [];
+						$post_meta    = Core::get_meta_values( $post->ID, $post->post_type );
 
-							// If an AMP page, convert to valid AMP HTML.
-							if ( $is_amp ) {
-								$html = Utils\generate_amp_partial( $html );
-							}
-
-							$item['html'] = $html;
+						if ( ! empty( $post_meta ) ) {
+							$item['meta'] = $post_meta;
 						}
+					}
 
-						// If $fields includes category, get the post categories.
-						if ( in_array( 'category', $fields ) ) {
-							$item['category'] = get_the_terms( $post->ID, 'category' );
-						}
+					// If $fields includes type, get the post type.
+					if ( in_array( 'type', $fields ) ) {
+						$item['type'] = $post->post_type;
+					}
 
-						// If $fields includes tags, get the post tags.
-						if ( in_array( 'tags', $fields ) ) {
-							$item['tags'] = get_the_terms( $post->ID, 'post_tag' );
-						}
+					// If $fields includes author and the post isn't set to hide author, get the post author.
+					if ( in_array( 'author', $fields ) && empty( get_post_meta( $post->ID, 'newspack_listings_hide_author', true ) ) ) {
+						$item['author'] = get_the_author_meta( 'display_name', $post->post_author );
+					}
 
-						// If $fields includes excerpt, get the post excerpt.
-						if ( in_array( 'excerpt', $fields ) ) {
-							$item['excerpt'] = Utils\get_listing_excerpt( $post );
-						}
+					$item['test'] = 'Brody';
 
-						// If $fields includes media, get the featured image + caption.
-						if ( in_array( 'media', $fields ) ) {
-							$item['media'] = [
-								'image'   => get_the_post_thumbnail_url( $post->ID, 'medium' ),
-								'caption' => get_the_post_thumbnail_caption( $post->ID ),
-							];
-						}
+					// If $fields includes sponsors include sponsors info.
+					if ( in_array( 'sponsors', $fields ) ) {
+						$item['sponsors'] = Utils\get_sponsors( $post->ID, 'native' );
+					}
 
-						// If $fields includes meta, get all Newspack Listings meta fields.
-						// Append sponsors and author info to this field so we can avoid having to register custom REST fields.
-						if ( in_array( 'meta', $fields ) || in_array( 'author', $fields ) ) {
-							$item['meta'] = [];
-							$post_meta    = Core::get_meta_values( $post->ID, $post->post_type );
-
-							if ( ! empty( $post_meta ) ) {
-								$item['meta'] = $post_meta;
-							}
-
-							// Include sponsors info.
-							$item['meta']['sponsors'] = Utils\get_sponsors( $post->ID, 'native' );
-
-							// If $fields includes author and the post isn't set to hide author, get the post author.
-							if ( in_array( 'author', $fields ) && empty( get_post_meta( $post->ID, 'newspack_listings_hide_author', true ) ) ) {
-								$item['meta']['author'] = get_the_author_meta( 'display_name', $post->post_author );
-							}
-						}
-
-						// If $fields includes type, get the post type.
-						if ( in_array( 'type', $fields ) ) {
-							$item['type'] = $post->post_type;
-						}
-
-						return $item;
-					},
-					$listings_query->posts
-				),
-				200
+					return $item;
+				},
+				$listings_query->posts
 			);
 
 			// Provide next URL if there are more pages.
@@ -387,18 +424,17 @@ final class Newspack_Listings_Api {
 						'amp'        => $is_amp,
 						'_fields'    => 'html',
 					],
-					rest_url( '/newspack-listings/v1/listings' )
+					rest_url( '/' . self::$namespace . '/listings' )
 				);
 			}
 
 			if ( ! empty( $next_url ) ) {
 				$response->header( 'next-url', $next_url );
 			}
-
-			return $response;
 		}
 
-		return new \WP_REST_Response( [] );
+		$response = new \WP_REST_Response( $listings );
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -74,6 +74,7 @@ final class Newspack_Listings_Core {
 		add_filter( 'newspack_listings_hide_author', [ __CLASS__, 'hide_author' ] );
 		add_filter( 'newspack_listings_hide_publish_date', [ __CLASS__, 'hide_publish_date' ] );
 		add_filter( 'newspack_theme_featured_image_post_types', [ __CLASS__, 'support_featured_image_options' ] );
+		add_filter( 'newspack_sponsors_post_types', [ __CLASS__, 'support_newspack_sponsors' ] );
 		register_activation_hook( NEWSPACK_LISTINGS_FILE, [ __CLASS__, 'activation_hook' ] );
 	}
 
@@ -824,6 +825,19 @@ final class Newspack_Listings_Core {
 	public static function activation_hook() {
 		self::register_post_types();
 		flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
+	}
+
+	/**
+	 * If using the Newspack Sponsors plugin, add support for sponsors to all listings.
+	 *
+	 * @param array $post_types Array of supported post types.
+	 * @return array Filtered array of supported post types.
+	 */
+	public static function support_newspack_sponsors( $post_types ) {
+		return array_merge(
+			$post_types,
+			array_values( self::NEWSPACK_LISTINGS_POST_TYPES )
+		);
 	}
 }
 

--- a/includes/newspack-listings-utils.php
+++ b/includes/newspack-listings-utils.php
@@ -346,3 +346,25 @@ function generate_amp_partial( $html ) {
 	}
 	return \AMP_DOM_Utils::get_content_from_dom( $dom );
 }
+
+/**
+ * Get sponsors for the given listing.
+ *
+ * @param int    $post_id ID of the listing.
+ * @param string $scope 'Native' or 'underwritten'.
+ * @param string $type 'Post' or 'archive'.
+ *
+ * @return array|boolean Array of sponsors, or false if none.
+ */
+function get_sponsors( $post_id = null, $scope = null, $type = 'post' ) {
+	// Bail if we don't have the Sponsors plugin.
+	if ( ! function_exists( '\Newspack_Sponsors\get_all_sponsors' ) ) {
+		return false;
+	}
+
+	if ( null === $post_id ) {
+		$post_id = get_the_ID();
+	}
+
+	return \Newspack_Sponsors\get_all_sponsors( $post_id, $scope, $type );
+}

--- a/src/assets/shared/listing.scss
+++ b/src/assets/shared/listing.scss
@@ -2,6 +2,15 @@
 
 .newspack-listings {
 	&__listing-post {
+		display: block;
+
+		@media only screen and ( min-width: $tablet_width ) {
+			.media-position-left &,
+			.media-position-right & {
+				display: flex;
+			}
+		}
+
 		+ .is-link {
 			padding-left: 0;
 			padding-right: 0;
@@ -47,18 +56,6 @@
 
 		.type-scale-10 & {
 			font-size: 162.5%;
-		}
-	}
-
-	&__listing-post,
-	&__listing-link {
-		display: block;
-
-		@media only screen and ( min-width: $tablet_width ) {
-			.media-position-left &,
-			.media-position-right & {
-				display: flex;
-			}
 		}
 	}
 
@@ -124,5 +121,15 @@
 
 	&__column-reverse {
 		flex-direction: row-reverse;
+	}
+
+	&__sponsors {
+		align-items: center;
+		display: flex;
+
+		.sponsor-logos {
+			border-right: 1px solid var( --newspack-listings--grey-light );
+			margin-right: 0.75rem;
+		}
 	}
 }

--- a/src/blocks/curated-list/edit.js
+++ b/src/blocks/curated-list/edit.js
@@ -117,7 +117,7 @@ const CuratedListEditorComponent = ( {
 			const posts = await apiFetch( {
 				path: addQueryArgs( '/newspack-listings/v1/listings', {
 					query: { ...query, maxItems: MAX_EDITOR_ITEMS }, // Get up to MAX_EDITOR_ITEMS listings in the editor so we can show all locations.
-					_fields: 'id,title,author,category,tags,excerpt,media,meta,type',
+					_fields: 'id,title,author,category,tags,excerpt,media,meta,type,sponsors',
 				} ),
 			} );
 			setAttributes( { listingIds: posts.map( post => post.id ) } );

--- a/src/blocks/listing/edit.js
+++ b/src/blocks/listing/edit.js
@@ -188,7 +188,7 @@ const ListingEditorComponent = ( {
 
 		return (
 			<div className="newspack-listings__listing-editor newspack-listings__listing">
-				<Listing attributes={ parent.curatedList.attributes } error={ error } post={ post } />
+				<Listing attributes={ attributes } error={ error } post={ post } />
 				{ post && (
 					<Button
 						isLink

--- a/src/blocks/listing/edit.js
+++ b/src/blocks/listing/edit.js
@@ -69,7 +69,7 @@ const ListingEditorComponent = ( {
 				path: addQueryArgs( '/newspack-listings/v1/listings', {
 					per_page: 100,
 					id: listingId,
-					_fields: 'id,title,author,category,tags,excerpt,media,meta',
+					_fields: 'id,title,author,category,tags,excerpt,media,meta,sponsors',
 				} ),
 			} );
 

--- a/src/blocks/listing/listing.js
+++ b/src/blocks/listing/listing.js
@@ -3,7 +3,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
 import { Fragment, RawHTML } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -11,6 +11,8 @@ import { decodeEntities } from '@wordpress/html-entities';
 export const Listing = ( { attributes, error, post } ) => {
 	// Parent Curated List block attributes.
 	const { showAuthor, showCategory, showTags, showExcerpt, showImage, showCaption } = attributes;
+	const { meta } = post;
+	const { sponsors = false, author = false } = meta;
 
 	return (
 		<div className="newspack-listings__listing-post entry-wrapper">
@@ -35,7 +37,12 @@ export const Listing = ( { attributes, error, post } ) => {
 			) }
 			{ post && post.title && (
 				<div className="newspack-listings__listing-meta">
-					{ showCategory && post.category.length && ! post.newspack_post_sponsors && (
+					{ sponsors && 0 < sponsors.length && (
+						<span className="cat-links sponsor-label">
+							<span className="flag">{ sponsors[ 0 ].sponsor_flag }</span>
+						</span>
+					) }
+					{ showCategory && post.category.length && ! sponsors && (
 						<div className="cat-links">
 							{ post.category.map( ( category, index ) => (
 								<Fragment key="index">
@@ -46,8 +53,40 @@ export const Listing = ( { attributes, error, post } ) => {
 						</div>
 					) }
 					<h3 className="newspack-listings__listing-title">{ decodeEntities( post.title ) }</h3>
-					{ showAuthor && post.author && (
-						<cite>{ __( 'By', 'newpack-listings' ) + ' ' + decodeEntities( post.author ) }</cite>
+					{ sponsors && 0 < sponsors.length && (
+						<div className="newspack-listings__sponsors">
+							<span className="sponsor-logos">
+								{ sponsors.map( sponsor => {
+									return (
+										<img
+											key={ sponsor.sponsor_id }
+											src={ sponsor.sponsor_logo.src }
+											width={ sponsor.sponsor_logo.img_width }
+											height={ sponsor.sponsor_logo.img_height }
+											alt={ sponsor.sponsor_name }
+										/>
+									);
+								} ) }
+							</span>
+							<span className="sponsor-byline">
+								{ sponsors.map( ( sponsor, index ) =>
+									sprintf(
+										'%s%s%s%s',
+										0 === index ? sponsor.sponsor_byline + ' ' : '',
+										1 < sponsors.length && index + 1 === sponsors.length
+											? __( ' and ', 'newspack-listings' )
+											: '',
+										sponsor.sponsor_name,
+										2 < sponsors.length && index + 1 < sponsors.length
+											? _x( ', ', 'separator character', 'newspack-listings' )
+											: ''
+									)
+								) }
+							</span>
+						</div>
+					) }
+					{ showAuthor && author && ! sponsors && (
+						<cite>{ __( 'By', 'newpack-listings' ) + ' ' + decodeEntities( author ) }</cite>
 					) }
 
 					{ showExcerpt && post.excerpt && <RawHTML>{ post.excerpt }</RawHTML> }

--- a/src/blocks/listing/listing.js
+++ b/src/blocks/listing/listing.js
@@ -11,8 +11,15 @@ import { decodeEntities } from '@wordpress/html-entities';
 export const Listing = ( { attributes, error, post } ) => {
 	// Parent Curated List block attributes.
 	const { showAuthor, showCategory, showTags, showExcerpt, showImage, showCaption } = attributes;
-	const { meta } = post;
-	const { sponsors = false, author = false } = meta;
+	const {
+		author = '',
+		category = [],
+		excerpt = '',
+		media = {},
+		sponsors = false,
+		tags = [],
+		title = '',
+	} = post;
 
 	return (
 		<div className="newspack-listings__listing-post entry-wrapper">
@@ -21,38 +28,38 @@ export const Listing = ( { attributes, error, post } ) => {
 					{ error }
 				</Notice>
 			) }
-			{ showImage && post && post.media && post.media.image && (
+			{ showImage && post && media && media.image && (
 				<figure className="newspack-listings__listing-featured-media">
 					<img
 						className="newspack-listings__listing-thumbnail"
-						src={ post.media.image }
-						alt={ post.media.caption || post.title }
+						src={ media.image }
+						alt={ media.caption || title }
 					/>
-					{ showCaption && post.media.caption && (
+					{ showCaption && media.caption && (
 						<figcaption className="newspack-listings__listing-caption">
-							{ post.media.caption }
+							{ media.caption }
 						</figcaption>
 					) }
 				</figure>
 			) }
-			{ post && post.title && (
+			{ post && (
 				<div className="newspack-listings__listing-meta">
 					{ sponsors && 0 < sponsors.length && (
 						<span className="cat-links sponsor-label">
 							<span className="flag">{ sponsors[ 0 ].sponsor_flag }</span>
 						</span>
 					) }
-					{ showCategory && post.category.length && ! sponsors && (
+					{ showCategory && category.length && ! sponsors && (
 						<div className="cat-links">
-							{ post.category.map( ( category, index ) => (
+							{ category.map( ( _category, index ) => (
 								<Fragment key="index">
-									{ decodeEntities( category.name ) }
-									{ index + 1 < post.category.length && ', ' }
+									{ decodeEntities( _category.name ) }
+									{ index + 1 < _category.length && ', ' }
 								</Fragment>
 							) ) }
 						</div>
 					) }
-					<h3 className="newspack-listings__listing-title">{ decodeEntities( post.title ) }</h3>
+					<h3 className="newspack-listings__listing-title">{ decodeEntities( title ) }</h3>
 					{ sponsors && 0 < sponsors.length && (
 						<div className="newspack-listings__sponsors">
 							<span className="sponsor-logos">
@@ -89,15 +96,15 @@ export const Listing = ( { attributes, error, post } ) => {
 						<cite>{ __( 'By', 'newpack-listings' ) + ' ' + decodeEntities( author ) }</cite>
 					) }
 
-					{ showExcerpt && post.excerpt && <RawHTML>{ post.excerpt }</RawHTML> }
+					{ showExcerpt && excerpt && <RawHTML>{ excerpt }</RawHTML> }
 
-					{ showTags && post.tags.length && (
+					{ showTags && tags.length && (
 						<p>
 							<strong>{ __( 'Tagged: ', 'newspack-listings' ) }</strong>
-							{ post.tags.map( ( tag, index ) => (
+							{ tags.map( ( tag, index ) => (
 								<Fragment key="index">
 									{ decodeEntities( tag.name ) }
-									{ index + 1 < post.tags.length && ', ' }
+									{ index + 1 < tags.length && ', ' }
 								</Fragment>
 							) ) }
 						</p>

--- a/src/templates/listing.php
+++ b/src/templates/listing.php
@@ -18,62 +18,139 @@ call_user_func(
 			return;
 		}
 
+		// Get native sponsors.
+		$sponsors = Utils\get_sponsors( $post->ID, 'native' );
 		?>
 	<li class="newspack-listings__listing">
 	<article class="newspack-listings__listing-post">
-		<a class="newspack-listings__listing-link" href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>">
-			<?php if ( $attributes['showImage'] ) : ?>
-				<?php
-				$featured_image = get_the_post_thumbnail( $post->ID, 'large' );
-				if ( ! empty( $featured_image ) ) :
-					?>
-					<figure class="newspack-listings__listing-featured-media">
+		<?php if ( $attributes['showImage'] ) : ?>
+			<?php
+			$featured_image = get_the_post_thumbnail( $post->ID, 'large' );
+			if ( ! empty( $featured_image ) ) :
+				?>
+				<figure class="newspack-listings__listing-featured-media">
+					<a class="newspack-listings__listing-link" href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>">
 						<?php echo wp_kses_post( $featured_image ); ?>
 						<?php if ( $attributes['showCaption'] ) : ?>
-						<figcaption class="newspack-listings__listing-caption">
-							<?php echo wp_kses_post( get_the_post_thumbnail_caption( $post->ID ) ); ?>
-						</figcaption>
+							<figcaption class="newspack-listings__listing-caption">
+								<?php echo wp_kses_post( get_the_post_thumbnail_caption( $post->ID ) ); ?>
+							</figcaption>
 						<?php endif; ?>
-					</figure>
+					</a>
+				</figure>
+			<?php endif; ?>
+		<?php endif; ?>
+
+		<div class="newspack-listings__listing-meta">
+			<?php
+			if ( ! empty( $sponsors ) && isset( $sponsors[0]['sponsor_flag'] ) ) :
+				?>
+				<span class="cat-links sponsor-label">
+					<span class="flag">
+						<?php echo esc_html( $sponsors[0]['sponsor_flag'] ); ?>
+					</span>
+				</span>
+				<?php
+			elseif ( $attributes['showCategory'] ) :
+				$categories = get_the_terms( $post->ID, 'category' );
+
+				if ( is_array( $categories ) && 0 < count( $categories ) ) :
+					?>
+					<div class="newspack-listings__category cat-links">
+						<?php
+						$category_index = 0;
+						foreach ( $categories as $category ) {
+							$term_url = get_term_link( $category->slug, 'category' );
+
+							if ( empty( $term_url ) ) {
+								$term_url = '#';
+							}
+							echo wp_kses_post( $category->name );
+
+							if ( $category_index + 1 < count( $categories ) ) {
+								echo esc_html( ', ' );
+							}
+
+							$category_index ++;
+						}
+						?>
+					</div>
 				<?php endif; ?>
 			<?php endif; ?>
 
-			<div class="newspack-listings__listing-meta">
-				<?php
-				if ( $attributes['showCategory'] ) :
-					$categories = get_the_terms( $post->ID, 'category' );
-
-					if ( is_array( $categories ) && 0 < count( $categories ) ) :
-						?>
-						<div class="newspack-listings__category cat-links">
+			<a class="newspack-listings__listing-link" href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>">
+				<h3 class="newspack-listings__listing-title"><?php echo wp_kses_post( $post->post_title ); ?></h3>
+			</a>
+			<?php if ( ! empty( $sponsors ) ) : ?>
+				<div class="newspack-listings__sponsors">
+					<?php
+					$sponsor_logos = array_reduce(
+						$sponsors,
+						function( $acc, $sponsor ) {
+							if ( ! empty( $sponsor['sponsor_logo'] ) ) {
+								$logo        = $sponsor['sponsor_logo'];
+								$logo['url'] = ! empty( $sponsor['sponsor_url'] ) ? $sponsor['sponsor_url'] : false;
+								$acc[]       = $logo;
+							}
+							return $acc;
+						},
+						[]
+					);
+					?>
+					<?php if ( ! empty( $sponsor_logos ) ) : ?>
+						<span class="sponsor-logos">
 							<?php
-							$category_index = 0;
-							foreach ( $categories as $category ) {
-								$term_url = get_term_link( $category->slug, 'category' );
-
-								if ( empty( $term_url ) ) {
-									$term_url = '#';
-								}
-								echo wp_kses_post( $category->name );
-
-								if ( $category_index + 1 < count( $categories ) ) {
-									echo esc_html( ', ' );
+							foreach ( $sponsor_logos as $logo ) {
+								if ( empty( $logo['src'] ) || empty( $logo['img_width'] ) || empty( $logo['img_height'] ) ) {
+									continue;
 								}
 
-								$category_index ++;
+								$has_url = ! empty( $logo['url'] );
+
+								echo wp_kses_post(
+									sprintf(
+										'%1$s<img src="%2$s" width="%3$s" height="%4$s" />%5$s',
+										$has_url ? '<a href="' . esc_url( $logo['url'] ) . '" target="_blank" rel="noreferrer">' : '',
+										esc_url( $logo['src'] ),
+										esc_attr( $logo['img_width'] ),
+										esc_attr( $logo['img_height'] ),
+										$has_url ? '</a>' : ''
+									)
+								);
 							}
 							?>
-						</div>
+						</span>
 					<?php endif; ?>
-				<?php endif; ?>
+					<span class="sponsor-byline">
+						<?php
+						$sponsor_index = 0;
+						$sponsor_count = count( $sponsors );
+						foreach ( $sponsors as $sponsor ) {
+							$has_url = ! empty( $sponsor['sponsor_url'] );
+							echo wp_kses_post(
+								sprintf(
+									'%1$s%2$s%3$s%4$s%5$s%6$s',
+									0 === $sponsor_index ? esc_html( $sponsor['sponsor_byline'] ) . ' ' : '',
+									1 < $sponsor_count && $sponsor_index + 1 === $sponsor_count ? __( ' and ', 'newspack-listings' ) : '',
+									$has_url ? '<a href="' . esc_url( $sponsor['sponsor_url'] ) . '" target="_blank" rel="noreferrer">' : '',
+									esc_html( $sponsor['sponsor_name'] ),
+									$has_url ? '</a>' : '',
+									2 < $sponsor_count && $sponsor_index + 1 < $sponsor_count ? _x( ', ', 'separator character', 'newspack-listings' ) : ''
+								)
+							);
 
-				<h3 class="newspack-listings__listing-title"><?php echo wp_kses_post( $post->post_title ); ?></h3>
-				<?php if ( $attributes['showAuthor'] && empty( get_post_meta( $post->ID, 'newspack_listings_hide_author', true ) ) ) : ?>
-				<cite>
-					<?php echo wp_kses_post( __( 'By', 'newspack-listings' ) . ' ' . get_the_author_meta( 'display_name', $post->post_author ) ); ?>
-				</cite>
-				<?php endif; ?>
+							$sponsor_index++;
+						}
+						?>
+					</span>
+				</div>
+			<?php elseif ( $attributes['showAuthor'] && empty( get_post_meta( $post->ID, 'newspack_listings_hide_author', true ) ) ) : ?>
+			<cite>
+				<?php echo wp_kses_post( __( 'By', 'newspack-listings' ) . ' ' . get_the_author_meta( 'display_name', $post->post_author ) ); ?>
+			</cite>
+			<?php endif; ?>
 
+			<a class="newspack-listings__listing-link" href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>">
 				<?php
 				if ( $attributes['showExcerpt'] ) {
 					echo wp_kses_post( Utils\get_listing_excerpt( $post ) );
@@ -103,8 +180,8 @@ call_user_func(
 						</p>
 					<?php endif; ?>
 				<?php endif; ?>
-			</div>
-		</a>
+			</a>
+		</div>
 	</article>
 	</li>
 		<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support for Newspack Sponsors to listings, both on individual listing pages and in curated lists.

Closes #35.

### How to test the changes in this Pull Request:

1. Check out [this branch](https://github.com/Automattic/newspack-sponsors/pull/58) in the Newspack Sponsors repo. This lets the Listings plugin add support for sponsors to its own custom post types. Make sure you have at least one native and one underwriter sponsor published on your site.
2. Edit a listing of any type. Confirm there's now a "Sponsors" sidebar panel which lets you choose sponsors, just like on regular posts and pages.
3. Apply a native and an underwriter sponsor to the listing and update.
4. View the listing's front-end page. Confirm that both native and underwriter sponsors are shown as they would be on a regular post, whether or not the listing is set to hide its author via the "Hide listing author" option:
  - For native sponsors: "Sponsored" flag replaces categories, sponsor logos and byline replaces author byline.
  - For underwriters: The underwriter's logo and messaging appears at the top of the content.

<img width="1145" alt="Screen Shot 2021-06-04 at 4 21 03 PM" src="https://user-images.githubusercontent.com/2230142/120868274-ed0c6480-c550-11eb-80b0-7f9c81540371.png">

5. On another post or page, create two Curated List blocks, one in Query mode and the other in Specific Listings mode.
6. In both blocks, add the sponsored listing. Confirm that in both blocks, the editor preview shows the listing with native sponsors (underwriters are not shown in non-singular contexts). Confirm that the sponsor flag, logos, and byline are shown whether or not the "Show Category" and "Show Author" settings are enabled for the block.

<img width="824" alt="Screen Shot 2021-06-04 at 4 23 47 PM" src="https://user-images.githubusercontent.com/2230142/120868411-3fe61c00-c551-11eb-99cf-2005484baeec.png">

7. View the post's front-end. Confirm that the curated list is rendered with sponsor info as it is in the editor preview.
8. Test with multiple sponsors, with curated list blocks with both sponsored and unsponsored listings, and with different block attributes.
9. Temporarily deactivate the Newspack Sponsors plugin and verify that everything still works, but falls back gracefully without showing the sponsors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
