### PR TITLE
fix: shadow taxonomy sidebar on post with no meta

### DIFF
--- a/src/editor/shadow-taxonomies/index.js
+++ b/src/editor/shadow-taxonomies/index.js
@@ -25,7 +25,7 @@ export const ShadowTaxonomiesComponent = ( {
 	createNotice,
 	editPost,
 	getEditedPostAttribute,
-	meta,
+	meta = {},
 	postId,
 	updateMetaValue,
 } ) => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Certain post types (read: Reusable Blocks) don't return a `meta` object when using `getEditedPostAttribute( 'meta' )`. This fixes a hard editor crash for post types like this.

### How to test the changes in this Pull Request:

1. On `epic/phase-2`, edit a Reusable Block. Observe an error message that prevents the editor from loading:

<img width="874" alt="Screen Shot 2021-06-04 at 11 56 06 AM" src="https://user-images.githubusercontent.com/2230142/120843869-db649600-c52b-11eb-8fc4-de304cea7922.png">

2. Check out this branch, refresh the editor, and confirm that the crash no longer happens.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
