### PR TITLE
fix: PHP warning on plugin activation

### DIFF
--- a/includes/class-newspack-listings-taxonomies.php
+++ b/includes/class-newspack-listings-taxonomies.php
@@ -53,6 +53,7 @@ final class Newspack_Listings_Taxonomies {
 		add_action( 'admin_init', [ __CLASS__, 'handle_orphaned_terms' ] );
 		add_filter( 'rest_prepare_taxonomy', [ __CLASS__, 'hide_taxonomy_sidebar' ], 10, 2 );
 		add_filter( 'the_content', [ __CLASS__, 'maybe_append_parent_listings' ] );
+		register_activation_hook( NEWSPACK_LISTINGS_FILE, [ __CLASS__, 'activation_hook' ] );
 	}
 
 	/**
@@ -658,6 +659,13 @@ final class Newspack_Listings_Taxonomies {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Register taxonomies on plugin activation.
+	 */
+	public static function activation_hook() {
+		self::register_tax();
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a few PHP warnings that are thrown when activating the plugin, due to unregistered taxonomies.

### How to test the changes in this Pull Request:

1. On `epic/phase-2`, deactivate and activate the plugin. Observe the following warnings being thrown on activation:

```
Warning: array_filter() expects parameter 1 to be array, object given in /Users/site/Local Sites/newspack/app/public/wp-content/plugins/newspack-listings/includes/class-newspack-listings-taxonomies.php on line 622
Warning: count(): Parameter must be an array or an object that implements Countable in /Users/site/Local Sites/newspack/app/public/wp-content/plugins/newspack-listings/includes/class-newspack-listings-taxonomies.php on line 625
Warning: array_filter() expects parameter 1 to be array, object given in /Users/site/Local Sites/newspack/app/public/wp-content/plugins/newspack-listings/includes/class-newspack-listings-taxonomies.php on line 622
Warning: count(): Parameter must be an array or an object that implements Countable in /Users/site/Local Sites/newspack/app/public/wp-content/plugins/newspack-listings/includes/class-newspack-listings-taxonomies.php on line 625
```

2. Check out this branch.
3. Deactivate and reactivate again, confirm that the warnings no longer happen.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
