### PR TITLE
Update price block to use placeholder and large font size

### DIFF
--- a/src/blocks/price/edit.js
+++ b/src/blocks/price/edit.js
@@ -6,12 +6,14 @@ import { InspectorControls } from '@wordpress/block-editor';
 import {
 	PanelBody,
 	PanelRow,
+	Placeholder,
 	SelectControl,
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
+import { currencyDollar } from '@wordpress/icons';
 
 export const PriceEditor = ( { attributes, isSelected, setAttributes } ) => {
 	const { currencies = {}, currency: defaultCurrency = 'USD' } = window.newspack_listings_data;
@@ -74,18 +76,18 @@ export const PriceEditor = ( { attributes, isSelected, setAttributes } ) => {
 				</PanelBody>
 			</InspectorControls>
 
-			<h2 className="newspack-listings__price">
-				{ isSelected ? (
+			{ isSelected ? (
+				<Placeholder
+					icon={ currencyDollar }
+					label={ __( 'Price', 'newspack-listings' ) }
+					isColumnLayout
+				>
 					<TextControl
 						label={ sprintf(
-							__( 'Enter price in %s', 'newspack-listings' ),
-							currency || defaultCurrency
-						) }
-						type="number"
-						placeholder={ sprintf(
 							__( 'Price in %s', 'newspack-listings' ),
 							currency || defaultCurrency
 						) }
+						type="number"
 						value={ price }
 						onChange={ value => {
 							setAttributes( {
@@ -93,10 +95,12 @@ export const PriceEditor = ( { attributes, isSelected, setAttributes } ) => {
 							} );
 						} }
 					/>
-				) : (
-					<>{ formattedPrice }</>
-				) }
-			</h2>
+				</Placeholder>
+			) : (
+				<p className="newspack-listings__price has-large-font-size">
+					<strong>{ formattedPrice }</strong>
+				</p>
+			) }
 		</>
 	);
 };

--- a/src/blocks/price/editor.scss
+++ b/src/blocks/price/editor.scss
@@ -1,7 +1,0 @@
-.newspack-listings {
-	&__price {
-		.components-text-control__input {
-			font-size: 2rem;
-		}
-	}
-}

--- a/src/blocks/price/index.js
+++ b/src/blocks/price/index.js
@@ -8,7 +8,6 @@ import { Icon, currencyDollar } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import './editor.scss';
 import { PriceEditor } from './edit';
 import metadata from './block.json';
 const { attributes, category, name } = metadata;

--- a/src/blocks/price/view.php
+++ b/src/blocks/price/view.php
@@ -37,7 +37,7 @@ function register_block() {
  * @return string $content content.
  */
 function render_block( $attributes ) {
-	return '<h2 class="newspack-listings__price">' . esc_html( $attributes['formattedPrice'] ) . '</h2>';
+	return '<p class="newspack-listings__price has-large-font-size"><strong>' . esc_html( $attributes['formattedPrice'] ) . '</strong></p>';
 }
 
 register_block();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I don't like the current style of the block when it's selected in the editor. This PR changes this to use `Placeholder`.

I'm also not sure why we need to use an `h2`, to me it doesn't make sense and we should be using a `p` with `has-large-font-size` (this could potentially even be a Setting in the sidebar? Maybe combined with an alignment setting?)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Test the Price block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
