### PR TITLE
fix: use synced attributes for ListContainer directly

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -30,3 +30,4 @@ node_modules
 /bin
 /src/**/*.js
 *.scss
+import

--- a/src/blocks/list-container/edit.js
+++ b/src/blocks/list-container/edit.js
@@ -105,7 +105,6 @@ const mapStateToProps = ( select, ownProps ) => {
 
 	return {
 		innerBlocks,
-		parent,
 	};
 };
 

--- a/src/blocks/list-container/edit.js
+++ b/src/blocks/list-container/edit.js
@@ -7,9 +7,8 @@ import { Notice, PanelRow, Spinner } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 
-const ListContainerEditorComponent = ( { clientId, innerBlocks, isSelected, parent } ) => {
-	const parentAttributes = parent.attributes || {};
-	const { queryMode, queryOptions, isSelected: parentIsSelected, showSortUi } = parentAttributes;
+const ListContainerEditorComponent = ( { attributes, clientId, innerBlocks } ) => {
+	const { queryMode, queryOptions, showSortUi } = attributes;
 	const { order } = queryOptions;
 
 	if ( queryMode && ! showSortUi ) {
@@ -93,11 +92,7 @@ const ListContainerEditorComponent = ( { clientId, innerBlocks, isSelected, pare
 					'newspack-listings/marketplace',
 					'newspack-listings/place',
 				] }
-				renderAppender={ () =>
-					queryMode || ( ! isSelected && ! parentIsSelected ) ? null : (
-						<InnerBlocks.ButtonBlockAppender />
-					)
-				}
+				renderAppender={ () => <InnerBlocks.ButtonBlockAppender /> }
 			/>
 		</div>
 	);
@@ -105,10 +100,8 @@ const ListContainerEditorComponent = ( { clientId, innerBlocks, isSelected, pare
 
 const mapStateToProps = ( select, ownProps ) => {
 	const { clientId } = ownProps;
-	const { getBlock, getBlockParents } = select( 'core/block-editor' );
+	const { getBlock } = select( 'core/block-editor' );
 	const innerBlocks = getBlock( clientId ).innerBlocks || [];
-	const parentId = getBlockParents( clientId )[ 0 ] || null;
-	const parent = getBlock( parentId );
 
 	return {
 		innerBlocks,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#63 refactored how we pass block attributes from the parent Curated List block to its inner list container and individual listing blocks by automatically setting attributes for its children directly. However, the list container block is still attempting to look up attributes from its parent instead of using its own synced attributes, which results in a JS error in certain situations.

Slightly related, I also removed the condition for the parent block needing to be selected in order to show a block appender button, which is something that used the faulty logic but we shouldn't need to refactor because we've already removed the condition in phase 2 PRs.

### How to test the changes in this Pull Request:

Somewhat difficult to replicate locally, as a curated list in query mode needs have been created on a plugin build prior to #63. Then, after updating the plugin to the latest release, you may experience a block crash in the editor and a JS console error about `can't read property queryOptions of undefined`.

The error was reported on [this page](https://quepasamedia.com/wp-admin/post.php?post=1391155&action=edit) and I've confirmed that patching the plugin installed on that site has fixed the issue.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
