### PR TITLE
fix: missing condition for block appender in list container

### DIFF
--- a/src/blocks/list-container/edit.js
+++ b/src/blocks/list-container/edit.js
@@ -92,7 +92,7 @@ const ListContainerEditorComponent = ( { attributes, clientId, innerBlocks } ) =
 					'newspack-listings/marketplace',
 					'newspack-listings/place',
 				] }
-				renderAppender={ () => <InnerBlocks.ButtonBlockAppender /> }
+				renderAppender={ () => ( queryMode ? null : <InnerBlocks.ButtonBlockAppender /> ) }
 			/>
 		</div>
 	);


### PR DESCRIPTION
#73 removed the requirement for Curated List to be selected before its child list container's block appender button can appear, but it removed a bit too much. The condition should match https://github.com/Automattic/newspack-listings/blob/epic/phase-2/src/blocks/list-container/edit.js#L96:

```
renderAppender={ () => ( queryMode ? null : <InnerBlocks.ButtonBlockAppender /> ) }
```