### PR TITLE
fix: default listings to one-column-wide.php post template

### DIFF
--- a/includes/newspack-listings-utils.php
+++ b/includes/newspack-listings-utils.php
@@ -29,7 +29,6 @@ function sanitize_array( $array ) {
 	return $array;
 }
 
-
 /**
  * Loads a template with given data in scope.
  *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This walks back a "feature" established in phase 2 which lets editors choose a post template (default, single feature, or single wide) if using a Newspack theme. As initially implemented, listings will default to whatever is set in the Customizer as the default post template; however, because v1 of Listings defaulted to single wide, this causes preexisting listings to change to whatever is set in the customizer. This PR defaults all listings to single wide, so will not cause any changes to the templates for preexisting listings, but still allows the template to be updated per listing.

Closes https://github.com/Automattic/newspack-listings/issues/76#issuecomment-865363365.

### How to test the changes in this Pull Request:

1. While on `master`, create some listings of any type. Observe that there's no "Post Attributes" sidebar panel for choosing a listing, and that listings are shown on the front-end with single wide template settings (no widget sidebar).
2. Check out `epic/phase-2` and observe that there's now a "Post Attributes" panel for choosing a template, but that it defaults to whatever is set in Customizer > Template Settings > Post Settings (most likely "Default"). Observe that the listings are now shown on the front-end with the default template (with widget sidebar)
3. Check out this branch, now confirm that the Post Attributes sidebar defaults to "One column wide." Confirm that they're shown as such on the front-end (no widget sidebar).
4. Change the setting to another template, update, and confirm that the template is updated on the front-end for that listing only.
5. Also confirm that new listings default to "One column wide".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
