### PR TITLE
fix: memory leaks from legacy term utilities

### DIFF
--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -68,7 +68,6 @@ final class Newspack_Listings_Core {
 	public function __construct() {
 		add_action( 'admin_menu', [ __CLASS__, 'add_plugin_page' ] );
 		add_action( 'init', [ __CLASS__, 'register_post_types' ] );
-		add_action( 'admin_init', [ __CLASS__, 'convert_legacy_taxonomies' ] );
 		add_filter( 'body_class', [ __CLASS__, 'set_template_class' ] );
 		add_action( 'save_post', [ __CLASS__, 'sync_post_meta' ], 10, 2 );
 		add_filter( 'newspack_listings_hide_author', [ __CLASS__, 'hide_author' ] );
@@ -841,111 +840,6 @@ final class Newspack_Listings_Core {
 			$post_types,
 			array_values( self::NEWSPACK_LISTINGS_POST_TYPES )
 		);
-	}
-
-	/**
-	 * Convert legacy custom taxonomies to regular post categories and tags.
-	 * Helpful for sites that have been using v1 of the Listings plugin.
-	 */
-	public static function convert_legacy_taxonomies() {
-		if ( defined( 'NEWSPACK_LISTINGS_MIGRATE_TAXONOMIES' ) && true === NEWSPACK_LISTINGS_MIGRATE_TAXONOMIES ) {
-			$custom_category_slug = 'newspack_lst_cat';
-			$custom_tag_slug      = 'newspack_lst_tag';
-
-			$category_args = [
-				'hierarchical'  => true,
-				'public'        => false,
-				'rewrite'       => false,
-				'show_in_menu'  => false,
-				'show_in_rest'  => false,
-				'show_tagcloud' => false,
-				'show_ui'       => false,
-			];
-			$tag_args      = [
-				'hierarchical'  => false,
-				'public'        => false,
-				'rewrite'       => false,
-				'show_in_menu'  => false,
-				'show_in_rest'  => false,
-				'show_tagcloud' => false,
-				'show_ui'       => false,
-			];
-
-			// Temporarily register the taxonomies for all Listing CPTs.
-			$post_types = array_values( self::NEWSPACK_LISTINGS_POST_TYPES );
-			register_taxonomy( $custom_category_slug, $post_types, $category_args );
-			register_taxonomy( $custom_tag_slug, $post_types, $tag_args );
-
-			// Get a list of the custom terms.
-			$custom_terms = get_terms(
-				[
-					'taxonomy'   => [ $custom_category_slug, $custom_tag_slug ],
-					'hide_empty' => false,
-				]
-			);
-
-			// If we don't have any terms from the legacy taxonomies, no need to proceed.
-			if ( is_wp_error( $custom_terms ) || 0 === count( $custom_terms ) ) {
-				unregister_taxonomy( $custom_category_slug );
-				unregister_taxonomy( $custom_tag_slug );
-				return;
-			}
-
-			foreach ( $custom_terms as $term ) {
-				// See if we have any corresponding terms already.
-				$corresponding_taxonomy = $custom_category_slug === $term->taxonomy ? 'category' : 'post_tag';
-				$corresponding_term     = get_term_by( 'name', $term->name, $corresponding_taxonomy, ARRAY_A );
-
-				// If not, create the term.
-				if ( ! $corresponding_term ) {
-					$corresponding_term = wp_insert_term(
-						$term->name,
-						$corresponding_taxonomy,
-						[
-							'description' => $term->description,
-							'slug'        => $term->slug,
-						]
-					);
-				}
-
-				// Get any posts with the legacy term.
-				$posts_with_custom_term = new \WP_Query(
-					[
-						'post_type' => $post_types,
-						'per_page'  => 1000,
-						'tax_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-							[
-								'taxonomy' => $term->taxonomy,
-								'field'    => 'term_id',
-								'terms'    => $term->term_id,
-							],
-						],
-					]
-				);
-
-				// Apply the new term to the post.
-				if ( $posts_with_custom_term->have_posts() ) {
-					while ( $posts_with_custom_term->have_posts() ) {
-						$posts_with_custom_term->the_post();
-						wp_set_post_terms(
-							get_the_ID(), // Post ID to apply the new term.
-							[ $corresponding_term['term_id'] ], // Term ID of the new term.
-							$corresponding_taxonomy, // Category or tag.
-							true // Append the term without deleting existing terms.
-						);
-					}
-				}
-
-				// Finally, delete the legacy term.
-				if ( defined( 'NEWSPACK_LISTINGS_ENV' ) && 'production' === NEWSPACK_LISTINGS_ENV ) {
-					wp_delete_term( $term->term_id, $term->taxonomy );
-				}
-			}
-
-			// Unregister the legacy taxonomies.
-			unregister_taxonomy( $custom_category_slug );
-			unregister_taxonomy( $custom_tag_slug );
-		}
 	}
 }
 

--- a/includes/importer/class-newspack-listings-importer.php
+++ b/includes/importer/class-newspack-listings-importer.php
@@ -149,13 +149,13 @@ final class Newspack_Listings_Importer {
 		}
 
 		if ( self::$is_dry_run ) {
-			WP_CLI::line( "\n===================\n=     Dry Run     =\n===================\n" );
+			WP_CLI::log( "\n===================\n=     Dry Run     =\n===================\n" );
 		}
 
 		if ( 0 < $start_row ) {
-			WP_CLI::line( 'Starting CSV import at row ' . $start_row . '...' );
+			WP_CLI::log( 'Starting CSV import at row ' . $start_row . '...' );
 		} else {
-			WP_CLI::line( 'Starting CSV import...' );
+			WP_CLI::log( 'Starting CSV import...' );
 		}
 		self::import_data( $file_path, $start_row, $max_rows );
 		WP_CLI::success( 'Completed! Processed ' . ( self::$row_number - $start_row ) . ' records.' );
@@ -301,7 +301,7 @@ final class Newspack_Listings_Importer {
 			],
 		];
 
-		WP_CLI::line( 'Importing data for ' . $post['post_title'] . '...' );
+		WP_CLI::log( 'Importing data for ' . $post['post_title'] . '...' );
 
 		// If a post already exists, update it.
 		if ( $existing_post ) {

--- a/includes/migration/class-newspack-listings-migration.php
+++ b/includes/migration/class-newspack-listings-migration.php
@@ -60,7 +60,7 @@ final class Newspack_Listings_Migration {
 		}
 
 		WP_CLI::add_command(
-			'newspack-listings taxonomies',
+			'newspack-listings taxonomies convert',
 			[ __CLASS__, 'run_cli_command' ],
 			[
 				'shortdesc' => 'Migrate legacy listing taxonomies to core post taxonomies.',
@@ -91,7 +91,7 @@ final class Newspack_Listings_Migration {
 			WP_CLI::log( "\n===================\n=     Dry Run     =\n===================\n" );
 		}
 
-		WP_CLI::log( 'Checking for legacy taxonomy terms...' );
+		WP_CLI::log( "Checking for legacy taxonomy terms...\n" );
 
 		$converted_taxonomies = self::convert_legacy_taxonomies();
 
@@ -100,9 +100,11 @@ final class Newspack_Listings_Migration {
 		} else {
 			WP_CLI::success(
 				sprintf(
-					'Completed! Converted %1$s categories and %2$s tags.',
+					'Completed! Converted %1$s %2$s and %3$s %4$s.',
 					count( $converted_taxonomies['category'] ),
-					count( $converted_taxonomies['post_tag'] )
+					1 > count( $converted_taxonomies['category'] ) ? 'categories' : 'category',
+					count( $converted_taxonomies['post_tag'] ),
+					1 > count( $converted_taxonomies['post_tag'] ) ? 'tags' : 'tag'
 				)
 			);
 		}

--- a/includes/migration/class-newspack-listings-migration.php
+++ b/includes/migration/class-newspack-listings-migration.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Migration utilities for Newspack Listings.
+ *
+ * @package Newspack_Listings
+ */
+
+namespace Newspack_Listings;
+
+use \WP_CLI as WP_CLI;
+use \Newspack_Listings\Newspack_Listings_Core as Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Importer class.
+ * Sets up CLI-based importer for listings.
+ */
+final class Newspack_Listings_Migration {
+	/**
+	 * Whether the script is running as a dry-run.
+	 *
+	 * @var Newspack_Listings_Migration
+	 */
+	public static $is_dry_run = false;
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var Newspack_Listings_Migration
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Main Newspack_Listings_Migration instance.
+	 * Ensures only one instance of Newspack_Listings_Migration is loaded or can be loaded.
+	 *
+	 * @return Newspack_Listings_Migration - Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', [ __CLASS__, 'add_cli_command' ] );
+	}
+
+	/**
+	 * Register the 'newspack-listings import' WP CLI command.
+	 */
+	public static function add_cli_command() {
+		if ( ! class_exists( 'WP_CLI' ) ) {
+			return;
+		}
+
+		WP_CLI::add_command(
+			'newspack-listings taxonomies',
+			[ __CLASS__, 'run_cli_command' ],
+			[
+				'shortdesc' => 'Migrate legacy listing taxonomies to core post taxonomies.',
+				'synopsis'  => [
+					[
+						'type'        => 'flag',
+						'name'        => 'dry-run',
+						'description' => 'Whether to do a dry run.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Run the 'newspack-listings taxonomy' WP CLI command.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args.
+	 */
+	public static function run_cli_command( $args, $assoc_args ) {
+		// If a dry run, we won't persist any data.
+		self::$is_dry_run = isset( $assoc_args['dry-run'] ) ? true : false;
+
+		if ( self::$is_dry_run ) {
+			WP_CLI::log( "\n===================\n=     Dry Run     =\n===================\n" );
+		}
+
+		WP_CLI::log( 'Checking for legacy taxonomy terms...' );
+
+		$converted_taxonomies = self::convert_legacy_taxonomies();
+
+		if ( 0 === count( $converted_taxonomies['category'] ) && 0 === count( $converted_taxonomies['post_tag'] ) ) {
+			WP_CLI::success( 'Completed! No legacy categories or tags found.' );
+		} else {
+			WP_CLI::success(
+				sprintf(
+					'Completed! Converted %1$s categories and %2$s tags.',
+					count( $converted_taxonomies['category'] ),
+					count( $converted_taxonomies['post_tag'] )
+				)
+			);
+		}
+	}
+
+	/**
+	 * Convert legacy custom taxonomies to regular post categories and tags.
+	 * Helpful for sites that have been using v1 of the Listings plugin.
+	 *
+	 * @return object Object containing converted term info.
+	 */
+	public static function convert_legacy_taxonomies() {
+		$converted_taxonomies = [
+			'category' => [],
+			'post_tag' => [],
+		];
+		$custom_category_slug = 'newspack_lst_cat';
+		$custom_tag_slug      = 'newspack_lst_tag';
+
+		$category_args = [
+			'hierarchical'  => true,
+			'public'        => false,
+			'rewrite'       => false,
+			'show_in_menu'  => false,
+			'show_in_rest'  => false,
+			'show_tagcloud' => false,
+			'show_ui'       => false,
+		];
+		$tag_args      = [
+			'hierarchical'  => false,
+			'public'        => false,
+			'rewrite'       => false,
+			'show_in_menu'  => false,
+			'show_in_rest'  => false,
+			'show_tagcloud' => false,
+			'show_ui'       => false,
+		];
+
+		// Temporarily register the taxonomies for all Listing CPTs.
+		$post_types = array_values( Core::NEWSPACK_LISTINGS_POST_TYPES );
+		register_taxonomy( $custom_category_slug, $post_types, $category_args );
+		register_taxonomy( $custom_tag_slug, $post_types, $tag_args );
+
+		// Get a list of the custom terms.
+		$custom_terms = get_terms(
+			[
+				'taxonomy'   => [ $custom_category_slug, $custom_tag_slug ],
+				'hide_empty' => false,
+			]
+		);
+
+		// If we don't have any terms from the legacy taxonomies, no need to proceed.
+		if ( is_wp_error( $custom_terms ) || 0 === count( $custom_terms ) ) {
+			unregister_taxonomy( $custom_category_slug );
+			unregister_taxonomy( $custom_tag_slug );
+			return $converted_taxonomies;
+		}
+
+		foreach ( $custom_terms as $term ) {
+			// See if we have any corresponding terms already.
+			$is_category            = $custom_category_slug === $term->taxonomy;
+			$corresponding_taxonomy = $is_category ? 'category' : 'post_tag';
+			$corresponding_term     = get_term_by( 'name', $term->name, $corresponding_taxonomy, ARRAY_A );
+
+			// If not, create the term.
+			if ( ! $corresponding_term && ! self::$is_dry_run ) {
+				$corresponding_term = wp_insert_term(
+					$term->name,
+					$corresponding_taxonomy,
+					[
+						'description' => $term->description,
+						'slug'        => $term->slug,
+					]
+				);
+			}
+
+			// Get any posts with the legacy term.
+			$posts_with_custom_term = new \WP_Query(
+				[
+					'post_type' => $post_types,
+					'per_page'  => 1000,
+					'tax_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+						[
+							'taxonomy' => $term->taxonomy,
+							'field'    => 'term_id',
+							'terms'    => $term->term_id,
+						],
+					],
+				]
+			);
+
+			// Apply the new term to the post.
+			if ( $posts_with_custom_term->have_posts() && ! self::$is_dry_run ) {
+				while ( $posts_with_custom_term->have_posts() ) {
+					$posts_with_custom_term->the_post();
+					wp_set_post_terms(
+						get_the_ID(), // Post ID to apply the new term.
+						[ $corresponding_term['term_id'] ], // Term ID of the new term.
+						$corresponding_taxonomy, // Category or tag.
+						true // Append the term without deleting existing terms.
+					);
+				}
+			}
+
+			// Finally, delete the legacy term.
+			if ( ! self::$is_dry_run ) {
+				wp_delete_term( $term->term_id, $term->taxonomy );
+			}
+
+			if ( $is_category ) {
+				$converted_taxonomies['category'][] = $term->term_id;
+			} else {
+				$converted_taxonomies['post_tag'][] = $term->term_id;
+			}
+
+			WP_CLI::log(
+				sprintf(
+					'Converted %1$s "%2$s".',
+					$is_category ? 'category' : 'tag',
+					$term->name
+				)
+			);
+		}
+
+		// Unregister the legacy taxonomies.
+		unregister_taxonomy( $custom_category_slug );
+		unregister_taxonomy( $custom_tag_slug );
+
+		return $converted_taxonomies;
+	}
+}
+
+Newspack_Listings_Migration::instance();

--- a/newspack-listings.php
+++ b/newspack-listings.php
@@ -35,3 +35,6 @@ require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/class-newspack-listings-
 // CLI importer files.
 require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/importer/newspack-listings-importer-utils.php';
 require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/importer/class-newspack-listings-importer.php';
+
+// Migration utilities.
+require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/migration/class-newspack-listings-migration.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes and improvements coming from feedback from the v2 beta test. Related issues reported in #76.

### How to test the changes in this Pull Request:

#### Legacy term conversion memory leak

In v2+ of Listings, listing CPTs use regular post categories and tags instead of separate custom taxonomies. We have a utility in place to check for and convert those legacy custom taxonomies, but it's an expensive operation. This PR avoids running the legacy term conversion script on every `admin_init` hook. Instead, moves the conversion to a WP CLI command so it has to be executed manually.

Addresses https://github.com/Automattic/newspack-listings/issues/76#issuecomment-867135473.

1. On `master`, create some legacy Listing Categories and Listing Tags and assign to some listings.
2. Check out this branch.
3. Run `wp newspack-listings taxonomies convert --dry-run` while SSHed into your test site. Confirm that the script iterates through your legacy categories and tags and prints info on each, but doesn't persist any changes.
4. Run `wp newspack-listings taxonomies convert`. This time confirm that the legacy terms are converted to regular post categories and tags, and that the converted post categories and tags are applied to the same listings that previously had the legacy terms.

#### Missing/orphan shadow term memory leak

Shadow terms are what we use to assign listings to other listings and posts/pages as related content. It's the most performant way to associate posts with other posts in WP. Unfortunately, terms sometimes go missing, or their posts get unpublished or deleted, resulting in orphaned terms. We have some utilities in place to check for and fix these missing/orphaned terms, but they are expensive operations. This PR avoids a memory leak caused by the functions that create missing or delete orphaned shadow terms by moving those to a WP CLI command.

1. On this branch, publish some listings of any type, e.g. a Place. The plugin should create a shadow term for each place when it's published.
2. Using WP CLI, look up the shadow terms using `wp term list newspack_lstngs_plc`. You should see a table of the shadow terms for your published places, e.g.:

```
+---------+--------------------+--------------------+-------------------------+-------------+--------+-------+
| term_id | term_taxonomy_id   | name               | slug                    | description | parent | count |
+---------+--------------------+--------------------+-------------------------+-------------+--------+-------+
| 488     | 488                | A New Place        | a-new-place             |             | 0      | 1     |
+---------+--------------------+--------------------+-------------------------+-------------+--------+-------+
```

3. Delete one of the terms using `wp term delete newspack_lstngs_plc <term_id>`. This will result in a Place with a missing shadow term.
4. Create an orphaned term by using `wp term create newspack_lstngs_plc Orphan --description="An orphaned term."`. This will result in a shadow term without a corresponding Place listing.
5. Run `wp newspack-listings taxonomies sync --dry-run`. Confirm that the script identifies your missing and orphaned terms, but doesn't actually make any DB changes.
6. Run `wp newspack-listings taxonomies sync`. This time confirm that the missing shadow term is created and the orphaned shadow term is deleted (using `wp term list newspack_lstngs_plc` again).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
