### PR TITLE
fix: errors and bugs related to WP 5.8

### DIFF
--- a/includes/class-newspack-listings-blocks.php
+++ b/includes/class-newspack-listings-blocks.php
@@ -60,9 +60,10 @@ final class Newspack_Listings_Blocks {
 			true
 		);
 
-		$total_count = 0;
-		$post_type   = get_post_type();
-		$post_types  = [];
+		$total_count     = 0;
+		$post_type       = get_post_type();
+		$post_types      = [];
+		$post_type_label = ! empty( $post_type ) ? get_post_type_object( $post_type )->labels->singular_name : 'Post';
 
 		foreach ( Core::NEWSPACK_LISTINGS_POST_TYPES as $label => $name ) {
 			$post_count           = wp_count_posts( $name )->publish;
@@ -77,7 +78,7 @@ final class Newspack_Listings_Blocks {
 			'newspack-listings-editor',
 			'newspack_listings_data',
 			[
-				'post_type_label' => get_post_type_object( $post_type )->labels->singular_name,
+				'post_type_label' => $post_type_label,
 				'post_type'       => $post_type,
 				'post_types'      => $post_types,
 				'taxonomies'      => [

--- a/src/assets/shared/listing.scss
+++ b/src/assets/shared/listing.scss
@@ -83,6 +83,7 @@
 		img {
 			display: inline-block;
 			vertical-align: top;
+			max-width: 100%;
 		}
 
 		.media-position-left & {

--- a/src/blocks/curated-list/editor.scss
+++ b/src/blocks/curated-list/editor.scss
@@ -32,6 +32,10 @@
 				border-top-color: var( --newspack-listings--border-light );
 			}
 		}
+
+		.query-mode .newspack-listings__list-container {
+			display: none;
+		}
 	}
 
 	&__placeholder {

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -90,6 +90,7 @@ export const getCuratedListClasses = ( className, attributes ) => {
 	const {
 		backgroundColor,
 		hasDarkBackground,
+		queryMode,
 		showNumbers,
 		showMap,
 		showSortUi,
@@ -114,6 +115,9 @@ export const getCuratedListClasses = ( className, attributes ) => {
 			classes.push( 'has-dark-background' );
 		}
 		classes.push( 'has-background-color' );
+	}
+	if ( queryMode ) {
+		classes.push( 'query-mode' );
 	}
 
 	classes.push( `type-scale-${ typeScale }` );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While testing another unrelated theme in WP 5.8, I discovered that Listings causes several errors and visual bugs in the new blocks-based Widgets screen. These changes should fix those issues.

### How to test the changes in this Pull Request:

1. Update WP to v5.8. The easiest way to do this is to install the [WordPress Beta Tester plugin](https://wordpress.org/plugins/wordpress-beta-tester/), go to Tools > Beta Testing, then set your site's update channel to "Bleeding Edge" then stream option to "Beta/RC only". Then go to Updates and update to a v5.8.x version.
2. Go to Appearance > Widgets. On `master` observe several PHP and JS errors that prevent the screen from rendering at all. e.g.

```
PHP Notice:  Trying to get property 'labels' of non-object in /Users/dkoo/Local Sites/newspack/app/public/wp-content/plugins/newspack-listings/includes/class-newspack-listings-blocks.php on line 82
```

3. Check out this branch and rebuild. Refresh the Widgets page. Now confirm that the screen loads as expected without errors coming from this plugin (you may still see other errors from other plugins and themes—a lot have conflicts with the new Widgets page! If the page still doesn't load try disabling other plugins until it does.).
4. Add two Curated List blocks to a widget area such as the sidebar. Make one "query" mode and the other "specific listings" mode. Set query params, add specific listings, and change visual options from the defaults in both blocks. Confirm that all functionality works as expected in the widget editor. Save your widget changes.
5. View the widget on the front-end and confirm that the Curated List blocks render as expected within the widget area.
6. Also repeat steps 4-5 in a post or page and confirm that nothing has changed in these contexts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
