### PR TITLE
fix: editor errors with reusable blocks

### DIFF
--- a/src/blocks/listing/listing.js
+++ b/src/blocks/listing/listing.js
@@ -54,7 +54,7 @@ export const Listing = ( { attributes, error, post } ) => {
 							{ category.map( ( _category, index ) => (
 								<Fragment key="index">
 									{ decodeEntities( _category.name ) }
-									{ index + 1 < _category.length && ', ' }
+									{ index + 1 < category.length && ', ' }
 								</Fragment>
 							) ) }
 						</div>

--- a/src/editor/shadow-taxonomies/child-listings.js
+++ b/src/editor/shadow-taxonomies/child-listings.js
@@ -264,11 +264,11 @@ const ChildListingsComponent = ( { hideChildren, postId, updateMetaValue } ) => 
 
 const mapStateToProps = select => {
 	const { getCurrentPostId, getEditedPostAttribute } = select( 'core/editor' );
-	const meta = getEditedPostAttribute( 'meta' );
+	const meta = getEditedPostAttribute( 'meta' ) || {};
 
 	return {
 		getEditedPostAttribute,
-		hideChildren: meta.newspack_listings_hide_children,
+		hideChildren: meta?.newspack_listings_hide_children,
 		postId: getCurrentPostId(),
 	};
 };

--- a/src/editor/shadow-taxonomies/parent-listings.js
+++ b/src/editor/shadow-taxonomies/parent-listings.js
@@ -333,11 +333,11 @@ const ParentListingsComponent = ( { hideParents, postId, updateMetaValue } ) => 
 
 const mapStateToProps = select => {
 	const { getCurrentPostId, getEditedPostAttribute } = select( 'core/editor' );
-	const meta = getEditedPostAttribute( 'meta' );
+	const meta = getEditedPostAttribute( 'meta' ) || {};
 
 	return {
 		getEditedPostAttribute,
-		hideParents: meta.newspack_listings_hide_parents,
+		hideParents: meta?.newspack_listings_hide_parents,
 		postId: getCurrentPostId(),
 	};
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug reported by a publisher that occurs in Reusable Blocks. This is similar to #66 but with related content JS.

Also fixes an unrelated minor bug with the display of multiple categories in the editor.

### How to test the changes in this Pull Request:

#### Reusable blocks errors

1. On `master`, go to Posts > Reusable Blocks and edit a reusable block.
2. Observe a JS console error similar to this (sometimes this will result in a hard editor crash, too):

```
An error occurred while running 'mapSelect': meta is undefined
```

3. Check out this branch, rebuild, refresh the reusable block. Confirm there's no longer a JS error or editor crash.
4. Add a Curated List block to the reusable block, insert the reusable block into a post, update the reusable block from the post, and confirm that all works as expected.

#### Category display in editor

1. Publish at least one listing with multiple categories.
2. Insert the listing into a Curated List block. On `master`, observe that the categories are rendered without any separator (in the editor only; on the front-end they are properly comma-separated).
3. Check out this branch, rebuild, refresh the editor. Confirm that the categories are now displayed with comma separators.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
