### PR TITLE
fix(wp-5.8): do not register post-specific sidebars in widgets page

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -19,18 +19,23 @@ import { ShadowTaxonomies } from './shadow-taxonomies';
 import { isListing } from './utils';
 import './style.scss';
 
+const { post_type: postType } = window?.newspack_listings_data;
+
 /**
  * Register Curated List blocks. Don't register if we're in a listing already
  * (to avoid possibly infinitely nesting lists within list items).
  */
 if ( isListing() ) {
-	const { post_types: postTypes } = window.newspack_listings_data || {};
+	const { post_types: postTypes } = window?.newspack_listings_data || {};
 
-	// Register plugin editor settings.
-	registerPlugin( 'newspack-listings-editor', {
-		render: Sidebar,
-		icon: null,
-	} );
+	// If we don't have a post type, we're probably not in a post editor, so we don't need to register the post editor sidebars.
+	if ( postType ) {
+		// Register plugin editor settings.
+		registerPlugin( 'newspack-listings-editor', {
+			render: Sidebar,
+			icon: null,
+		} );
+	}
 
 	// Register Event Dates block if we're editing an Event.
 	if ( isListing( postTypes.event.name ) ) {
@@ -48,8 +53,11 @@ if ( isListing() ) {
 	registerListingBlock();
 }
 
-// Register plugin editor settings.
-registerPlugin( 'newspack-listings-shadow-taxonomies', {
-	render: ShadowTaxonomies,
-	icon: null,
-} );
+// If we don't have a post type, we're probably not in a post editor, so we don't need to register the post taxonomy sidebars.
+if ( postType ) {
+	// Register plugin editor settings.
+	registerPlugin( 'newspack-listings-shadow-taxonomies', {
+		render: ShadowTaxonomies,
+		icon: null,
+	} );
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids potential JS errors and crashes in the new WP 5.8 widget blocks editor by not registering editor sidebars that assume we're in a post editor context.

### How to test the changes in this Pull Request:

This is somewhat difficult to test because it doesn't happen on every site nor even on every page load of every site it does happen on. [Here's a site where I saw it happening](https://wp58test-yubanet.newspackstaging.com/wp-admin/widgets.php) (ping me for credentials). But here's how you'd confirm the fix:

1. On `master`, on a site running WP 5.8, visit **Appearance > Widgets**. Observe several JS console errors like this which prevent the widgets UI from loading:

```
The above error occurred in the <WithDispatch(ChildListingsComponent)> component:
    in WithDispatch(ChildListingsComponent)
    in Unknown (created by WithSelect(WithDispatch(ChildListingsComponent)))
    in WithSelect(WithDispatch(ChildListingsComponent)) (created by ShadowTaxonomies)
    in ShadowTaxonomies (created by plugin_area_PluginArea)
    in div (created by plugin_area_PluginArea)
    in plugin_area_PluginArea (created by Layout)
    in div (created by CopyHandler)
    in CopyHandler (created by WidgetAreasBlockEditorProvider)
    in BlockRefsProvider (created by BlockEditorProvider)
    in BlockEditorProvider
    in Unknown (created by Context.Consumer)
    in WithRegistryProvider(BlockEditorProvider) (created by WidgetAreasBlockEditorProvider)
    in slot_fill_provider_SlotFillProvider (created by Provider)
    in provider_SlotFillProvider (created by Provider)
    in Provider (created by WidgetAreasBlockEditorProvider)
    in WidgetAreasBlockEditorProvider (created by Layout)
    in Layout

Consider adding an error boundary to your tree to customize error handling behavior.
Visit https://fb.me/react-error-boundaries to learn more about error boundaries. react-dom.js:19662:15
```

2. Check out this branch or install a built version of this branch on the affected site. Refresh the Widgets page and confirm that the crash no longer occurs.
3. Test inserting Curated List blocks into various widget areas and confirm that they render as expected in the editor and on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
