### PR TITLE
fix: avoid meta sync update error

### DIFF
--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -307,14 +307,7 @@ final class Newspack_Listings_Core {
 					'type'              => 'array',
 					'sanitize_callback' => 'Utils\sanitize_array',
 					'single'            => false,
-					'show_in_rest'      => [
-						'schema' => [
-							'type'  => 'array',
-							'items' => [
-								'type' => 'string',
-							],
-						],
-					],
+					'show_in_rest'      => false,
 					'auth_callback'     => function() {
 						return current_user_can( 'edit_posts' );
 					},
@@ -368,12 +361,7 @@ final class Newspack_Listings_Core {
 					'type'              => 'array',
 					'sanitize_callback' => 'Utils\sanitize_array',
 					'single'            => false,
-					'show_in_rest'      => [
-						'schema' => [
-							'type'  => 'array',
-							'items' => [ 'type' => 'object' ],
-						],
-					],
+					'show_in_rest'      => false,
 				],
 			],
 			'newspack_listings_business_hours'    => [
@@ -394,12 +382,7 @@ final class Newspack_Listings_Core {
 					'type'              => 'array',
 					'sanitize_callback' => 'Utils\sanitize_array',
 					'single'            => false,
-					'show_in_rest'      => [
-						'schema' => [
-							'type'  => 'array',
-							'items' => [ 'type' => 'object' ],
-						],
-					],
+					'show_in_rest'      => false,
 				],
 			],
 			'newspack_listings_locations'         => [
@@ -421,12 +404,7 @@ final class Newspack_Listings_Core {
 					'type'              => 'array',
 					'sanitize_callback' => 'Utils\sanitize_array',
 					'single'            => false,
-					'show_in_rest'      => [
-						'schema' => [
-							'type'  => 'array',
-							'items' => [ 'type' => 'object' ],
-						],
-					],
+					'show_in_rest'      => false,
 					'auth_callback'     => function() {
 						return current_user_can( 'edit_posts' );
 					},
@@ -449,7 +427,7 @@ final class Newspack_Listings_Core {
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 					'single'            => true,
-					'show_in_rest'      => true,
+					'show_in_rest'      => false,
 					'auth_callback'     => function() {
 						return current_user_can( 'edit_posts' );
 					},
@@ -472,7 +450,7 @@ final class Newspack_Listings_Core {
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 					'single'            => true,
-					'show_in_rest'      => true,
+					'show_in_rest'      => false,
 					'auth_callback'     => function() {
 						return current_user_can( 'edit_posts' );
 					},
@@ -514,14 +492,7 @@ final class Newspack_Listings_Core {
 					'type'              => 'array',
 					'sanitize_callback' => 'Utils\sanitize_array',
 					'single'            => false,
-					'show_in_rest'      => [
-						'schema' => [
-							'type'  => 'array',
-							'items' => [
-								'type' => 'integer',
-							],
-						],
-					],
+					'show_in_rest'      => false,
 					'auth_callback'     => function() {
 						return current_user_can( 'edit_posts' );
 					},

--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -371,32 +371,7 @@ final class Newspack_Listings_Core {
 					'show_in_rest'      => [
 						'schema' => [
 							'type'  => 'array',
-							'items' => [
-								'type'       => 'object',
-								'properties' => [
-									'address'      => [
-										'type' => 'string',
-									],
-									'addressLine2' => [
-										'type' => 'string',
-									],
-									'addressLine3' => [
-										'type' => 'string',
-									],
-									'city'         => [
-										'type' => 'string',
-									],
-									'region'       => [
-										'type' => 'string',
-									],
-									'postal'       => [
-										'type' => 'string',
-									],
-									'country'      => [
-										'type' => 'string',
-									],
-								],
-							],
+							'items' => [ 'type' => 'object' ],
 						],
 					],
 				],
@@ -422,28 +397,7 @@ final class Newspack_Listings_Core {
 					'show_in_rest'      => [
 						'schema' => [
 							'type'  => 'array',
-							'items' => [
-								'type'       => 'object',
-								'properties' => [
-									'name'  => [
-										'type' => 'string',
-									],
-									'hours' => [
-										'type'  => 'array',
-										'items' => [
-											'type'       => 'object',
-											'properties' => [
-												'opening' => [
-													'type' => 'string',
-												],
-												'closing' => [
-													'type' => 'string',
-												],
-											],
-										],
-									],
-								],
-							],
+							'items' => [ 'type' => 'object' ],
 						],
 					],
 				],
@@ -470,34 +424,7 @@ final class Newspack_Listings_Core {
 					'show_in_rest'      => [
 						'schema' => [
 							'type'  => 'array',
-							'items' => [
-								'type'       => 'object',
-								'properties' => [
-									'placeTitle'  => [
-										'type' => 'string',
-									],
-									'title'       => [
-										'type' => 'string',
-									],
-									'caption'     => [
-										'type' => 'string',
-									],
-									'id'          => [
-										'type' => 'string',
-									],
-									'coordinates' => [
-										'type'       => 'object',
-										'properties' => [
-											'latitude'  => [
-												'type' => 'number',
-											],
-											'longitude' => [
-												'type' => 'number',
-											],
-										],
-									],
-								],
-							],
+							'items' => [ 'type' => 'object' ],
 						],
 					],
 					'auth_callback'     => function() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids an error that prevents you from being able to update a listing post when certain blocks are present in the listing content. This stems from a failure to validate meta values against the REST schema when the synced values contain objects that might have unknown properties.

Some background: we look for certain blocks in listing content and sync their attributes to post meta. This is for the planned Phase 3 automated directory functionality; we need certain block attributes (such as locations, email addresses, phone numbers, etc.) to be easily queryable for front-end searching and filtering functionality. We implemented this sync early on so that we wouldn't have to go back to generate this data for listings that predate Phase 3. However, because in some cases we're saving all block attributes as post meta, any schema for these meta fields might not be 100% accurate in all cases. Saving attributes to a meta field that aren't listed in the meta field's schema will result in that field's value failing REST schema validation on future post updates, which short-circuits the update entirely.

We can avoid this error by not showing these meta values in REST; this shouldn't be needed because we don't need to access these meta fields via core REST API routes. Any usage of these meta fields for searching and filtering can and should be accomplished through custom REST routes where we can look up the meta values we need on the server.

Closes #29.

### How to test the changes in this Pull Request:

1. Create a new listing of any type.
2. Add a Contact Info block to the content (Jetpack must be active). Fill out all the fields. Here's an example block with attributes and content that I've confirmed replicates the error:

```
<!-- wp:jetpack/contact-info -->
<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/address {"address":"3915 McDermott BLVD","addressLine2":"Ste 100","city":"Plano","region":"TX","postal":"75025","linkToGoogleMaps":true} -->
<div class="wp-block-jetpack-address"><a href="https://www.google.com/maps/search/3915+McDermott BLVD,Ste 100,+Plano,+TX,+75025" target="_blank" rel="noopener noreferrer" title="Open address in Google Maps"><div class="jetpack-address__address jetpack-address__address1">3915 McDermott BLVD</div><div class="jetpack-address__address jetpack-address__address2">Ste 100</div><div><span class="jetpack-address__city">Plano</span>, <span class="jetpack-address__region">TX</span> <span class="jetpack-address__postal">75025</span></div></a></div>
<!-- /wp:jetpack/address -->

<!-- wp:jetpack/phone {"phone":"(Ann) 972.898.6600"} -->
<div class="wp-block-jetpack-phone"><span class="phone-prefix">(Ann) </span><a href="tel:9728986600">972.898.6600</a></div>
<!-- /wp:jetpack/phone -->

<!-- wp:jetpack/email {"email":"ann.oblenes@verizon.net"} -->
<div class="wp-block-jetpack-email"><a href="mailto:ann.oblenes@verizon.net">ann.oblenes@verizon.net</a></div>
<!-- /wp:jetpack/email -->

<!-- wp:paragraph -->
<p>(Elizabeth) 972.977.4678</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>elizabethritch@remax.net</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p><a href="http://realtyperformancepartners.com" target="_blank" data-type="URL" data-id="realtyperformancepartners.com" rel="noreferrer noopener">realtyperformancepartners.com</a></p>
<!-- /wp:paragraph --></div>
<!-- /wp:jetpack/contact-info -->
```

3. Publish the listing. The contact info attributes will be synced to post meta as `newspack_listings_contact_address`.
4. Make some change to the listing and attempt to update it. Observe an "Updating failed" editor error that prevents the listing from being updated at all:

![image](https://user-images.githubusercontent.com/2230142/125834662-60146ba4-90ad-49df-80ed-5cc5683771e3.png)

5. Check out this branch. Make some other change to the listing post and update again. This time confirm that the listing saves your changes without throwing any errors.
6. Update the values in the Contact Info block and update once again.
7. Using WP CLI, run `wp post meta list <your listing's post ID>` and inspect the value of the `newspack_listings_contact_address` meta field. It should match your latest updates and any updates you make to the Contact Info block's content and attributes going forward.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
