### PR TITLE
feat: bump max number of items per list from 20 to 50

### DIFF
--- a/src/blocks/curated-list/edit.js
+++ b/src/blocks/curated-list/edit.js
@@ -307,27 +307,20 @@ const CuratedListEditorComponent = ( {
 	 * @param {Object} listing Post object for listing to show.
 	 * @param {number} index Index of the item in the array.
 	 */
-	const renderQueriedListings = ( listing, index ) => {
-		// Only display up to the maxItems setting.
-		if ( index >= queryOptions.maxItems ) {
-			return null;
-		}
-
-		return (
-			<div key={ index } className="newspack-listings__listing-editor newspack-listings__listing">
-				<Listing attributes={ attributes } error={ error } post={ listing } />
-				{
-					<Button
-						isLink
-						href={ `/wp-admin/post.php?post=${ listing.id }&action=edit` }
-						target="_blank"
-					>
-						{ __( 'Edit this listing', 'newspack-listing' ) }
-					</Button>
-				}
-			</div>
-		);
-	};
+	const renderQueriedListings = ( listing, index ) => (
+		<div key={ index } className="newspack-listings__listing-editor newspack-listings__listing">
+			<Listing attributes={ attributes } error={ error } post={ listing } />
+			{
+				<Button
+					isLink
+					href={ `/wp-admin/post.php?post=${ listing.id }&action=edit` }
+					target="_blank"
+				>
+					{ __( 'Edit this listing', 'newspack-listing' ) }
+				</Button>
+			}
+		</div>
+	);
 
 	/**
 	 * Validate location data.

--- a/src/blocks/curated-list/edit.js
+++ b/src/blocks/curated-list/edit.js
@@ -116,7 +116,7 @@ const CuratedListEditorComponent = ( {
 			setError( null );
 			const posts = await apiFetch( {
 				path: addQueryArgs( '/newspack-listings/v1/listings', {
-					query: { ...query, maxItems: MAX_EDITOR_ITEMS }, // Get up to MAX_EDITOR_ITEMS listings in the editor so we can show all locations.
+					query: { maxItems: MAX_EDITOR_ITEMS, ...query }, // Get up to MAX_EDITOR_ITEMS listings in the editor so we can show all locations.
 					_fields: 'id,title,author,category,tags,excerpt,media,meta,type,sponsors',
 				} ),
 			} );

--- a/src/components/sidebar-query-controls.js
+++ b/src/components/sidebar-query-controls.js
@@ -243,7 +243,7 @@ class QueryControls extends Component {
 					setAttributes( { queryOptions: { ...queryOptions, maxItems: value } } )
 				}
 				min={ 1 }
-				max={ 20 }
+				max={ 50 }
 				required
 			/>,
 			<ToggleControl


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Bumps the max of number of listings that can be loaded at a time in a single Curated List block from 20 to 50.

Closes #94.

<img width="271" alt="Screen Shot 2021-07-16 at 11 18 23 AM" src="https://user-images.githubusercontent.com/2230142/125985160-0388ee7c-39d2-43cd-be54-b76c5f9b0f8b.png">

### How to test the changes in this Pull Request:

1. Insert a Curated List block in Query mode.
2. Under Query Settings, confirm that the "Max number of items" range control now allows the option to be set from 1–50.
3. Confirm that the number of posts shown in the list at a time matches the setting in the editor and on the front-end (and that when using "Load more" functionality, the pagination is batched by this same number).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
