### PR TITLE
feat: show classes for each category and tag on every listing

### DIFF
--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -687,6 +687,8 @@ final class Newspack_Listings_Core {
 	}
 
 	/**
+	 * Adds additional utility classes to the body element for single listing pages.
+	 *
 	 * If using the single-featured or wide templates, apply a body class to listing posts
 	 * so that they inherit theme styles for that template.
 	 *
@@ -695,6 +697,10 @@ final class Newspack_Listings_Core {
 	 */
 	public static function set_template_class( $classes ) {
 		if ( self::is_listing() ) {
+			$classes[]    = 'newspack-listings';
+			$term_classes = Utils\get_term_classes();
+			$classes      = array_merge( $classes, $term_classes );
+
 			$template = get_page_template_slug();
 			if ( 'single-feature.php' === $template ) {
 				$classes[] = 'post-template-single-feature';

--- a/includes/newspack-listings-utils.php
+++ b/includes/newspack-listings-utils.php
@@ -367,3 +367,49 @@ function get_sponsors( $post_id = null, $scope = null, $type = 'post' ) {
 
 	return \Newspack_Sponsors\get_all_sponsors( $post_id, $scope, $type );
 }
+
+/**
+ * Get an array of term-based class names for the given or current listing.
+ *
+ * @param int $post_id ID of the listing.
+ * @return array Array of term-based class names.
+ */
+function get_term_classes( $post_id = null ) {
+	if ( null === $post_id ) {
+		$post_id = get_the_ID();
+	}
+
+	// Base classes.
+	$base_classes = [];
+	$post_type    = get_post_type( $post_id );
+	if ( false !== $post_type ) {
+		$base_classes[] = 'type-' . $post_type;
+	}
+
+	// Build an array of class names for each category.
+	$category_classes = array_reduce(
+		get_the_category( $post_id ),
+		function( $acc, $category ) {
+			$acc[] = 'category-' . $category->slug;
+			return $acc;
+		},
+		[]
+	);
+
+	// Build an array of class names for each tag.
+	$tags        = get_the_terms( $post_id, 'post_tag' );
+	$tag_classes = array_reduce(
+		! empty( $tags ) ? $tags : [],
+		function( $acc, $tag ) {
+			$acc[] = 'tag-' . $tag->slug;
+			return $acc;
+		},
+		[]
+	);
+
+	return array_merge(
+		$base_classes,
+		$category_classes,
+		$tag_classes
+	);
+}

--- a/src/blocks/listing/listing.js
+++ b/src/blocks/listing/listing.js
@@ -8,6 +8,11 @@ import { Notice } from '@wordpress/components';
 import { Fragment, RawHTML } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 
+/**
+ * Internal dependencies.
+ */
+import { getTermClasses } from '../../editor/utils';
+
 export const Listing = ( { attributes, error, post } ) => {
 	// Parent Curated List block attributes.
 	const { showAuthor, showCategory, showTags, showExcerpt, showImage, showCaption } = attributes;
@@ -21,8 +26,11 @@ export const Listing = ( { attributes, error, post } ) => {
 		title = '',
 	} = post;
 
+	const classes = [ 'newspack-listings__listing-post', 'entry-wrapper' ];
+	const termClasses = getTermClasses( post );
+
 	return (
-		<div className="newspack-listings__listing-post entry-wrapper">
+		<div className={ classes.concat( termClasses ).join( ' ' ) }>
 			{ error && (
 				<Notice className="newspack-listings__error" status="error" isDismissible={ false }>
 					{ error }

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -281,3 +281,26 @@ export const getIcon = listingTypeSlug => {
 			return <Icon icon={ postList } />;
 	}
 };
+
+/**
+ * Get an array of term-based class names for the given or current listing.
+ *
+ * @param {object} post Post object for the post.
+ * @return {array} Array of term-based class names.
+ */
+export const getTermClasses = post => {
+	const classes = [];
+
+	if ( ! post.id || ! post.type ) {
+		return classes;
+	}
+
+	// Post type class.
+	classes.push( `type-${ post.type }` );
+
+	// Category and tag classes.
+	( post.category || [] ).forEach( category => classes.push( `category-${ category.slug }` ) );
+	( post.tags || [] ).forEach( tag => classes.push( `tag-${ tag.slug }` ) );
+
+	return classes;
+};

--- a/src/templates/listing.php
+++ b/src/templates/listing.php
@@ -18,11 +18,17 @@ call_user_func(
 			return;
 		}
 
+		// Class names for the listing.
+		$classes = array_merge(
+			[ 'newspack-listings__listing-post' ],
+			Utils\get_term_classes()
+		);
+
 		// Get native sponsors.
 		$sponsors = Utils\get_sponsors( $post->ID, 'native' );
 		?>
 	<li class="newspack-listings__listing">
-	<article class="newspack-listings__listing-post">
+	<article class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
 		<?php if ( $attributes['showImage'] ) : ?>
 			<?php
 			$featured_image = get_the_post_thumbnail( $post->ID, 'large' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds class names for each category, tag, and the listing post type whenever listings are shown in the following contexts:

* In Curated Lists on the `article` element for each listing item, in both the editor and on the front-end
* In Homepage Posts and Post Carousel blocks on the `article` or `div` element for each listing item, in both the editor and on the front-end (requires https://github.com/Automattic/newspack-blocks/pull/819)
* On single listing posts, on the `body` element

This should make it easier for publishers to apply custom CSS for specific categories, tags, or listing post types. An example use case would be if there were a tag called "Best of" that could be applied to any listing; all listings with that tag should show a custom "Best of" flag wherever they appear on the site.

Closes #53.

### How to test the changes in this Pull Request:

1. Check out this branch as well as https://github.com/Automattic/newspack-blocks/pull/819 and build both repos.
2. Publish several listings with various categories and tags assigned, and some with no terms.
3. View each listing individually, confirm that the body contains the following class names:
  - A `category-${ categorySlug }` class name for each category (if the post has any categories)
  - A `tag-${ tagSlug }` class name for each tag (if the post has any tags)
  - A `type-${ postType }` class name for the post type
4. On a post or page, add two Curated List blocks (one in specific mode and the other in query mode), a Homepage Posts and a Post Carousel block. Ensure that the test listings you published are shown in each. (You may need to split the Homepage Posts and Post Carousel blocks across different pages to get around the deduplication behavior.)
5. For each block, inspect the article element (usually `div` or `article`) in both the editor and on the front-end. In all cases the article should have the same class names as described in step 3.
6. Without any custom CSS, the visual appearance of all of these elements should be unchanged from `master`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
