### PR TITLE
fix: satisfy DatePicker prop dependency

### DIFF
--- a/src/blocks/event-dates/edit.js
+++ b/src/blocks/event-dates/edit.js
@@ -62,6 +62,7 @@ export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 						<DatePickerComponent
 							currentDate={ startDate ? new Date( startDate ) : null }
 							is12Hour={ true }
+							onMonthPreviewed={ () => {} }
 							onChange={ value => {
 								if (
 									! value || // If clearing the value.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Satisfy the `DatePickerComponent` `onMonthPreviewed` dependency with a `noop`.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #104.

### How to test the changes in this Pull Request:

1. On master branch, attempt to change the month of an event and see the block crashing
2. Switch to this branch, build and observe that you can switch months without crashing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
