### PR TITLE
feat: add CSS classes for hidden date, author

### DIFF
--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -701,6 +701,14 @@ final class Newspack_Listings_Core {
 			$term_classes = Utils\get_term_classes();
 			$classes      = array_merge( $classes, $term_classes );
 
+			if ( self::hide_publish_date() ) {
+				$classes[] = 'hide-date';
+			}
+
+			if ( self::hide_author() ) {
+				$classes[] = 'hide-author';
+			}
+
 			$template = get_page_template_slug();
 			if ( 'single-feature.php' === $template ) {
 				$classes[] = 'post-template-single-feature';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

This PR adds a CSS class to the body, each when the date or author is hidden on a listing.

It's one possible way to fix https://github.com/Automattic/newspack-theme/issues/1389. This is only needed to fix an issue in Newspack Sacha, so I'm open to alternative approaches; I also only added these classes to the plugin because I saw others related to the theme there, but if it's better to add to the theme, just let me know!

### How to test the changes in this Pull Request:

1. Apply the PR. 
2. Try hiding the date and author on a site-wide level under WP Admin > Listings > Settings; confirm each setting adds either a `hide-date` or `hide-author` body class.
3. Try toggling the hide date/author options on a per-listing level and confirm they affect which body classes appear (eg. if you have the date hidden site-wide, but set to show on one listing, it shouldn't have the `hide-date` class.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
