### PR TITLE
feat: allow empty prefix slug; tweaks for GDG import

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -30,4 +30,4 @@ node_modules
 /bin
 /src/**/*.js
 *.scss
-/import
+/release

--- a/includes/class-newspack-listings-api.php
+++ b/includes/class-newspack-listings-api.php
@@ -398,7 +398,7 @@ final class Newspack_Listings_Api {
 
 					// If $fields includes category, get the post categories.
 					if ( in_array( 'category', $fields ) ) {
-						$item['category'] = get_the_terms( $post->ID, 'category' );
+						$item['category'] = get_the_category( $post->ID );
 					}
 
 					// If $fields includes tags, get the post tags.

--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -143,6 +143,8 @@ final class Newspack_Listings_Core {
 	 */
 	public static function register_post_types() {
 		$settings          = Settings::get_settings();
+		$prefix            = $settings['newspack_listings_permalink_prefix'];
+		$prefix            = ! empty( $prefix ) ? $prefix . '/' : '';
 		$default_config    = [
 			'has_archive'  => false,
 			'public'       => true,
@@ -170,7 +172,7 @@ final class Newspack_Listings_Core {
 					'not_found'          => __( 'No events found.', 'newspack-listings' ),
 					'not_found_in_trash' => __( 'No events found in Trash.', 'newspack-listings' ),
 				],
-				'rewrite'  => [ 'slug' => $settings['newspack_listings_event_slug'] ],
+				'rewrite'  => [ 'slug' => $prefix . $settings['newspack_listings_event_slug'] ],
 				'template' => [ [ 'newspack-listings/event-dates' ] ],
 			],
 			'generic'     => [
@@ -190,7 +192,7 @@ final class Newspack_Listings_Core {
 					'not_found'          => __( 'No generic listings found.', 'newspack-listings' ),
 					'not_found_in_trash' => __( 'No generic listings found in Trash.', 'newspack-listings' ),
 				],
-				'rewrite' => [ 'slug' => $settings['newspack_listings_generic_slug'] ],
+				'rewrite' => [ 'slug' => $prefix . $settings['newspack_listings_generic_slug'] ],
 			],
 			'marketplace' => [
 				'labels'  => [
@@ -209,7 +211,7 @@ final class Newspack_Listings_Core {
 					'not_found'          => __( 'No Marketplace listings found.', 'newspack-listings' ),
 					'not_found_in_trash' => __( 'No Marketplace listings found in Trash.', 'newspack-listings' ),
 				],
-				'rewrite' => [ 'slug' => $settings['newspack_listings_marketplace_slug'] ],
+				'rewrite' => [ 'slug' => $prefix . $settings['newspack_listings_marketplace_slug'] ],
 			],
 			'place'       => [
 				'labels'  => [
@@ -228,7 +230,7 @@ final class Newspack_Listings_Core {
 					'not_found'          => __( 'No places found.', 'newspack-listings' ),
 					'not_found_in_trash' => __( 'No places found in Trash.', 'newspack-listings' ),
 				],
-				'rewrite' => [ 'slug' => $settings['newspack_listings_place_slug'] ],
+				'rewrite' => [ 'slug' => $prefix . $settings['newspack_listings_place_slug'] ],
 			],
 		];
 

--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -143,7 +143,6 @@ final class Newspack_Listings_Core {
 	 */
 	public static function register_post_types() {
 		$settings          = Settings::get_settings();
-		$prefix            = $settings['newspack_listings_permalink_prefix'];
 		$default_config    = [
 			'has_archive'  => false,
 			'public'       => true,
@@ -171,7 +170,7 @@ final class Newspack_Listings_Core {
 					'not_found'          => __( 'No events found.', 'newspack-listings' ),
 					'not_found_in_trash' => __( 'No events found in Trash.', 'newspack-listings' ),
 				],
-				'rewrite'  => [ 'slug' => $prefix . '/' . $settings['newspack_listings_event_slug'] ],
+				'rewrite'  => [ 'slug' => $settings['newspack_listings_event_slug'] ],
 				'template' => [ [ 'newspack-listings/event-dates' ] ],
 			],
 			'generic'     => [
@@ -191,7 +190,7 @@ final class Newspack_Listings_Core {
 					'not_found'          => __( 'No generic listings found.', 'newspack-listings' ),
 					'not_found_in_trash' => __( 'No generic listings found in Trash.', 'newspack-listings' ),
 				],
-				'rewrite' => [ 'slug' => $prefix . '/' . $settings['newspack_listings_generic_slug'] ],
+				'rewrite' => [ 'slug' => $settings['newspack_listings_generic_slug'] ],
 			],
 			'marketplace' => [
 				'labels'  => [
@@ -210,7 +209,7 @@ final class Newspack_Listings_Core {
 					'not_found'          => __( 'No Marketplace listings found.', 'newspack-listings' ),
 					'not_found_in_trash' => __( 'No Marketplace listings found in Trash.', 'newspack-listings' ),
 				],
-				'rewrite' => [ 'slug' => $prefix . '/' . $settings['newspack_listings_marketplace_slug'] ],
+				'rewrite' => [ 'slug' => $settings['newspack_listings_marketplace_slug'] ],
 			],
 			'place'       => [
 				'labels'  => [
@@ -229,7 +228,7 @@ final class Newspack_Listings_Core {
 					'not_found'          => __( 'No places found.', 'newspack-listings' ),
 					'not_found_in_trash' => __( 'No places found in Trash.', 'newspack-listings' ),
 				],
-				'rewrite' => [ 'slug' => $prefix . '/' . $settings['newspack_listings_place_slug'] ],
+				'rewrite' => [ 'slug' => $settings['newspack_listings_place_slug'] ],
 			],
 		];
 

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -30,13 +30,6 @@ final class Newspack_Listings_Settings {
 	public static function get_default_settings() {
 		return [
 			[
-				'description' => __( 'The URL prefix for all listings. This prefix will appear before the listing slug in all listing URLs.', 'newspack-listings' ),
-				'key'         => 'newspack_listings_permalink_prefix',
-				'label'       => __( 'Listings permalink prefix', 'newspack-listings' ),
-				'type'        => 'input',
-				'value'       => __( 'listings', 'newspack-listings' ),
-			],
-			[
 				'description' => __( 'The URL slug for event listings.', 'newspack-listings' ),
 				'key'         => 'newspack_listings_event_slug',
 				'label'       => __( 'Event listings slug', 'newspack-listings' ),

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -30,6 +30,14 @@ final class Newspack_Listings_Settings {
 	public static function get_default_settings() {
 		return [
 			[
+				'description' => __( 'The URL prefix for all listings. This prefix will appear before the listing slug in all listing URLs.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_permalink_prefix',
+				'label'       => __( 'Listings permalink prefix', 'newspack-listings' ),
+				'type'        => 'input',
+				'value'       => __( 'listings', 'newspack-listings' ),
+				'allow_empty' => true,
+			],
+			[
 				'description' => __( 'The URL slug for event listings.', 'newspack-listings' ),
 				'key'         => 'newspack_listings_event_slug',
 				'label'       => __( 'Event listings slug', 'newspack-listings' ),
@@ -103,10 +111,10 @@ final class Newspack_Listings_Settings {
 			$defaults,
 			function( $acc, $setting ) use ( $get_default ) {
 				$key   = $setting['key'];
-				$value = $get_default ? $setting['value'] : get_option( $key, $setting['value'] );
+				$value = $get_default ? $setting['value'] : get_option( $key, '' );
 
 				// Guard against empty strings, which can happen if an option is set and then unset.
-				if ( '' === $value && 'checkbox' !== $setting['type'] ) {
+				if ( empty( $setting['allow_empty'] ) && '' === $value && 'checkbox' !== $setting['type'] ) {
 					$value = $setting['value'];
 				}
 
@@ -195,7 +203,7 @@ final class Newspack_Listings_Settings {
 				esc_html( $setting['description'] )
 			);
 		} else {
-			if ( empty( $value ) ) {
+			if ( empty( $value ) && empty( $setting['allow_empty'] ) ) {
 				$value = $setting['value'];
 			}
 			printf(
@@ -219,8 +227,21 @@ final class Newspack_Listings_Settings {
 	public static function flush_permalinks( $old_value, $new_value, $option ) {
 		// Prevent empty slug value.
 		if ( empty( $new_value ) ) {
-			$default = self::get_settings( $option, true );
-			return update_option( $option, $default ); // Return early to prevent flushing rewrite rules twice.
+			$defaults = self::get_default_settings();
+			$matching = array_reduce(
+				$defaults,
+				function( $acc, $default_option_config ) use ( $option ) {
+					if ( $option === $default_option_config['key'] ) {
+						$acc = $default_option_config;
+					}
+					return $acc;
+				},
+				false
+			);
+
+			if ( $matching && empty( $matching['allow_empty'] ) ) {
+				return update_option( $option, $matching['value'] ); // Return early to prevent flushing rewrite rules twice.
+			}
 		}
 
 		Core::activation_hook();

--- a/includes/importer/class-newspack-listings-importer.php
+++ b/includes/importer/class-newspack-listings-importer.php
@@ -23,23 +23,44 @@ final class Newspack_Listings_Importer {
 	/**
 	 * The current row number of the CSV being processed.
 	 *
-	 * @var Newspack_Listings_Importer
+	 * @var $row_number
 	 */
 	public static $row_number;
 
 	/**
 	 * The directory containing the CSV file to be imported.
 	 *
-	 * @var Newspack_Listings_Importer
+	 * @var $import_dir
 	 */
 	public static $import_dir;
 
 	/**
 	 * Whether the script is running as a dry-run.
 	 *
-	 * @var Newspack_Listings_Importer
+	 * @var $is_dry_run
 	 */
 	public static $is_dry_run = false;
+
+	/**
+	 * Term ID for the "Directory" parent category.
+	 *
+	 * @var $directory_category
+	 */
+	public static $directory_category = false;
+
+	/**
+	 * Term ID for the "Featured" category.
+	 *
+	 * @var $featured_category
+	 */
+	public static $featured_category = false;
+
+	/**
+	 * Taxonomy slug for the listing Label custom taxonomy.
+	 *
+	 * @var $listing_label_tax
+	 */
+	public static $listing_label_tax = 'newspack_lst_label_tax';
 
 	/**
 	 * The single instance of the class.
@@ -75,6 +96,30 @@ final class Newspack_Listings_Importer {
 		if ( ! class_exists( 'WP_CLI' ) ) {
 			return;
 		}
+
+		WP_CLI::add_command(
+			'newspack-listings import-categories',
+			[ __CLASS__, 'import_categories' ],
+			[
+				'shortdesc' => 'Import directory categories from a CSV file.',
+				'synopsis'  => [
+					[
+						'type'        => 'assoc',
+						'name'        => 'file',
+						'description' => 'Path of the CSV file to import, relative to the plugin’s root directory.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'flag',
+						'name'        => 'dry-run',
+						'description' => 'Whether to do a dry run.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+				],
+			]
+		);
 
 		WP_CLI::add_command(
 			'newspack-listings import',
@@ -157,8 +202,140 @@ final class Newspack_Listings_Importer {
 		} else {
 			WP_CLI::log( 'Starting CSV import...' );
 		}
+
+		// Get the parent "Featured" category.
+		self::$directory_category = self::handle_terms( 'Directory' );
+
 		self::import_data( $file_path, $start_row, $max_rows );
 		WP_CLI::success( 'Completed! Processed ' . ( self::$row_number - $start_row ) . ' records.' );
+	}
+
+	/**
+	 * Run the 'newspack-listings import-categories' WP CLI command.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args.
+	 */
+	public static function import_categories( $args, $assoc_args ) {
+		$file_arg = isset( $assoc_args['file'] ) ? $assoc_args['file'] : false;
+
+		// If a dry run, we won't persist any data.
+		self::$is_dry_run = isset( $assoc_args['dry-run'] ) ? true : false;
+
+		$file_path = self::load_file( $file_arg );
+		if ( ! $file_path ) {
+			WP_CLI::error( 'Could not find file at ' . $file_arg );
+		}
+
+		if ( self::$is_dry_run ) {
+			WP_CLI::log( "\n===================\n=     Dry Run     =\n===================\n" );
+		}
+
+		// Get the parent "Featured" category.
+		self::$directory_category = self::handle_terms( 'Directory' );
+
+		// Start at 0.
+		self::$row_number = 0;
+
+		WP_CLI::log( 'Starting CSV import...' );
+
+		self::get_categories_from_csv( $file_path );
+		WP_CLI::success( 'Completed! Processed ' . self::$row_number . ' records.' );
+	}
+
+	/**
+	 * Load the category CSV file contents and start the import.
+	 *
+	 * @param string $file_path Full absolute file path for the CSV to process.
+	 *
+	 * @return void
+	 */
+	public static function get_categories_from_csv( $file_path ) {
+
+		// Check if the function mb_detect_encoding exists. The mbstring extension must be installed on the server.
+		$file_encoding = function_exists( 'mb_detect_encoding' ) ? mb_detect_encoding( $file_path, 'UTF-8, ISO-8859-1', true ) : false;
+
+		if ( $file_encoding ) {
+			setlocale( LC_ALL, 'en_US.' . $file_encoding );
+		}
+
+		@ini_set( 'auto_detect_line_endings', true ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
+		if ( $file_path && ( $file_handle = fopen( $file_path, 'r' ) ) !== false ) { // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure, WordPress.WP.AlternativeFunctions.file_system_read_fopen
+			$data           = [];
+			$all_terms      = [];
+			$column_headers = fgetcsv( $file_handle, 0 );
+
+			while ( ( $csv_row = fgetcsv( $file_handle, 0 ) ) !== false ) { // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+
+				foreach ( $column_headers as $key => $header ) {
+					if ( ! $header ) {
+						continue;
+					}
+					$data[ $header ] = ( isset( $csv_row[ $key ] ) ) ? trim( Importer_Utils\format_data( $csv_row[ $key ], $file_encoding ) ) : '';
+				}
+
+
+				self::$row_number++;
+				$all_terms[] = $data;
+			}
+			fclose( $file_handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose
+
+			$split_terms = array_reduce(
+				$all_terms,
+				function( $acc, $term ) {
+					if ( empty( $term['term_parent'] ) ) {
+						$acc['parent'][] = $term;
+					} else {
+						$acc['child'][] = $term;
+					}
+					return $acc;
+				},
+				[
+					'child'  => [],
+					'parent' => [],
+				]
+			);
+
+			foreach ( $split_terms['parent'] as $parent_term ) {
+				$options = [
+					'parent' => self::$directory_category,
+					'slug'   => $parent_term['term_slug'], // All parent categories should be nested under 'Directory' category.
+				];
+
+				if ( ! empty( $parent_term['term_content'] ) ) {
+					$options['description'] = $parent_term['term_content'];
+				}
+				$term = self::handle_terms( $parent_term['term_title'], 'category', $options );
+				WP_CLI::success(
+					sprintf(
+						'Category %s imported successfully as term ID %s.',
+						$parent_term['term_title'],
+						$term
+					)
+				);
+			}
+
+			foreach ( $split_terms['child'] as $child_term ) {
+				$parent  = get_term_by( 'slug', $child_term['term_parent'], 'category' );
+				$options = [
+					'parent' => $parent && isset( $parent->term_id ) ? $parent->term_id : self::$directory_category,
+					'slug'   => $child_term['term_slug'],
+				];
+
+				if ( ! empty( $child_term['term_content'] ) ) {
+					$options['description'] = $child_term['term_content'];
+				}
+				$term = self::handle_terms( $child_term['term_title'], 'category', $options );
+				WP_CLI::success(
+					sprintf(
+						'Category “%s” imported successfully as term ID %s.',
+						$child_term['term_title'],
+						$term
+					)
+				);
+			}
+		}
 	}
 
 	/**
@@ -338,37 +515,50 @@ final class Newspack_Listings_Importer {
 		$post['post_content'] = self::process_content( $data );
 
 		// Handle categories.
-		if ( ! self::$is_dry_run && ! empty( $data[ $field_map['post_category'] ] ) ) {
+		if ( ! empty( $data[ $field_map['post_category'] ] ) ) {
 			$category_names        = explode( $separator, $data[ $field_map['post_category'] ] );
 			$category_ids          = self::handle_terms( $category_names, 'category' );
 			$post['post_category'] = $category_ids;
 		}
 
-		// Handle tags.
-		if ( ! self::$is_dry_run && ! empty( $data[ $field_map['tags_input'] ] ) ) {
-			$tag_names = explode( $separator, $data[ $field_map['tags_input'] ] );
-			$tag_ids   = self::handle_terms( $tag_names, 'category' ); // For GDG, they want tags and categories to all be tags.
+		// GDG only: If the item has a `field_business_label` value, apply those as listing Label terms.
+		$listing_label_ids = [];
 
-			// For GDG, they want tags and categories to all be tags.
-			$post['post_category'] = array_merge( $post['post_category'], $tag_ids );
+		if ( ! empty( $data['field_business_label'] ) ) {
+			$labels_to_combine   = [
+				'LGTBQ-Owned BUSINESS'                     => 'LGTBQ-Owned/Operated',
+				'DBA MEMBER OUR LGBTQ Chamber of Commerce' => 'DBA Member-Our LGBTQ Chamber of Commerce',
+				'Recommended'                              => 'As Heard on KGAY',
+			];
+			$listing_label_names = explode( $separator, $data['field_business_label'] );
+			$listing_label_names = array_map(
+				function( $label_name ) use ( $labels_to_combine ) {
+					if ( in_array( $label_name, array_keys( $labels_to_combine ) ) ) {
+						return $labels_to_combine[ $label_name ];
+					}
+
+					return $label_name;
+				},
+				$listing_label_names
+			);
+
+			$listing_label_ids = self::handle_terms( $listing_label_names, self::$listing_label_tax );
+			$post['tax_input'] = [];
 		}
 
+		// Handle tags.
+		if ( ! empty( $data[ $field_map['tags_input'] ] ) ) {
+			$tag_names = explode( $separator, $data[ $field_map['tags_input'] ] );
+			$tag_ids   = self::handle_terms( $tag_names, 'post_tag' );
 
-		// GDG only: handle primary category. ALL-CAPS categories are primary.
-		$category_names   = ! empty( $category_names ) ? $category_names : [];
-		$tag_names        = ! empty( $tag_names ) ? $tag_names : [];
-		$primary_category = array_filter(
-			array_merge( $category_names, $tag_names ),
-			function( $cat_name ) {
-				return strtoupper( $cat_name ) === $cat_name;
-			}
-		);
-		if ( 0 < count( $primary_category ) ) {
-			$primary_category    = reset( $primary_category );
-			$primary_category_id = get_term_by( 'name', $primary_category, 'category' );
+			$post['tags_input'] = $tag_ids;
+		}
 
-			if ( $primary_category_id ) {
-				$post['meta_input']['_yoast_wpseo_primary_category'] = $primary_category_id;
+		// Handle meta fields.
+		$meta_keys = ! empty( $field_map['meta_input'] ) ? $field_map['meta_input'] : [];
+		foreach ( $meta_keys as $meta_key ) {
+			if ( ! empty( $data[ $meta_key ] ) ) {
+				$post['meta_input'] = array_merge( $post['meta_input'], [ $meta_key => $data[ $meta_key ] ] );
 			}
 		}
 
@@ -381,7 +571,22 @@ final class Newspack_Listings_Importer {
 		if ( self::$is_dry_run ) {
 			WP_CLI::success( $post['post_title'] . ' imported successfully.' );
 		} else {
-			$post_id = wp_insert_post( $post );
+			if ( $existing_post ) {
+				// If the post has already been imported, don't update the content as it may have already been worked on.
+				unset( $post['post_content'] );
+				$post_id = wp_update_post( $post );
+			} else {
+				$post_id = wp_insert_post( $post );
+			}
+
+			// GDG only: we don't want Yoast primary categories.
+			delete_post_meta( $post_id, '_yoast_wpseo_primary_category' );
+
+			// GDG only: now that we have a post, assign any listing label terms as needed.
+			if ( 0 < count( $listing_label_ids ) ) {
+				wp_set_object_terms( $post_id, $listing_label_ids, self::$listing_label_tax );
+			}
+
 			WP_CLI::success( $post['post_title'] . ' imported successfully as post ID ' . $post_id . '.' );
 		}
 	}
@@ -476,7 +681,7 @@ final class Newspack_Listings_Importer {
 					! empty( $instagram_handle ) ? '"url": "' . esc_url( 'https://instagram.com/' . $instagram_handle ) . '",' : ''
 				)
 			),
-			! empty( $featured_image ) ? wp_kses_post( sprintf( '<!-- wp:image {"id":%1$s,"sizeSlug":"large","linkDestination":"none"} --><figure class="wp-block-image size-large"><img src="%2$s" alt="" class="wp-image-%1$s"/></figure><!-- /wp:image -->', $featured_image, esc_url( wp_get_attachment_image_url( $featured_image, 'large' ) ) ) ) : '',
+			! empty( $featured_image ) ? wp_kses_post( sprintf( '<!-- wp:image {"id":%1$s,"sizeSlug":"large","linkDestination":"none"} --><figure class="wp-block-image size-large"><img src="%2$s" alt="" class="wp-image-%1$s"/></figure><!-- /wp:image -->', $featured_image, esc_url( str_replace( 'https://https://', 'https://', wp_get_attachment_image_url( $featured_image, 'large' ) ) ) ) ) : '',
 			Importer_Utils\clean_content( $raw_content ),
 			! empty( $contact_email ) ? wp_kses_post( sprintf( '<!-- wp:jetpack/email {"email":"%1$s"} --><div class="wp-block-jetpack-email"><a href="mailto:%1$s">%1$s</a></div><!-- /wp:jetpack/email -->', $contact_email ) ) : '',
 			! empty( $contact_phone ) ? wp_kses_post( sprintf( '<!-- wp:jetpack/phone {"phone":"%1$s"} --><div class="wp-block-jetpack-phone"><a href="tel:%2$s">%1$s</a></div><!-- /wp:jetpack/phone -->', $contact_phone, preg_replace( '/[^0-9]/', '', $contact_phone ) ) ) : '',
@@ -523,26 +728,72 @@ final class Newspack_Listings_Importer {
 	 *
 	 * @param array  $term_names Array of term names to look up.
 	 * @param string $taxonomy Name of the taxonomy to look up or create.
+	 * @param array  $options If given, use for creating or updating the term.
 	 *
 	 * @return array Array of term IDs.
 	 */
-	public static function handle_terms( $term_names, $taxonomy ) {
+	public static function handle_terms( $term_names, $taxonomy = 'category', $options = [] ) {
 		$term_ids = [];
+		$single   = false;
+
+		if ( is_string( $term_names ) ) {
+			$single     = true;
+			$term_names = [ $term_names ];
+		}
 
 		foreach ( $term_names as $term_name ) {
-			$term = get_term_by( 'name', $term_name, $taxonomy, ARRAY_A );
+			$term_name = (string) $term_name;
 
-			if ( ! $term ) {
-				$term = wp_insert_term( $term_name, $taxonomy );
+			if ( empty( $term_name ) ) {
+				continue;
 			}
 
-			// GDG only: remove existing tags, since they're being imported as categories.
-			$tag = get_term_by( 'name', $term_name, 'post_tag', ARRAY_A );
-			if ( $tag ) {
-				wp_delete_term( $tag['term_id'], 'post_tag' );
+			// For GDG, they originally wanted tags and categories to all be categories, but I disagree. Delete any categories that come from tags.
+			if ( 'post_tag' === $taxonomy ) {
+				$tag_as_category = get_term_by( 'name', $term_name, 'category' );
+				$tag_as_category = is_array( $tag_as_category ) && 0 < count( $tag_as_category ) ? reset( $tag_as_category ) : false;
+
+				if ( $tag_as_category ) {
+					wp_delete_term( $tag_as_category->term_id, 'category', [ 'default' => self::$directory_category ] );
+				}
 			}
 
-			$term_id    = $term['term_id'];
+			$terms = get_terms(
+				[
+					'hide_empty' => false,
+					'number'     => 1,
+					'name'       => $term_name,
+					'taxonomy'   => $taxonomy,
+				]
+			);
+			$term  = 0 < count( $terms ) ? (array) reset( $terms ) : false;
+			$args  = wp_parse_args(
+				$options,
+				[
+					'slug' => sanitize_title( $term_name ),
+				]
+			);
+
+			if ( ! self::$is_dry_run ) {
+				if ( $term && isset( $term['term_id'] ) ) {
+					wp_update_term( $term['term_id'], $taxonomy, $args );
+				} else {
+					$term = wp_insert_term( $term_name, $taxonomy, $args );
+				}
+			}
+
+			if ( is_wp_error( $term ) ) {
+				$err = sprintf( '❗ ERROR while importing %s: %s ', $term_name, $term->get_error_messages()[0] ?? '?' );
+				WP_CLI::log( $err );
+				continue;
+			}
+
+			$term_id = $term['term_id'] ?? 1;
+
+			if ( $single ) {
+				return $term_id;
+			}
+
 			$term_ids[] = $term_id;
 		}
 

--- a/src/templates/listing.php
+++ b/src/templates/listing.php
@@ -58,7 +58,7 @@ call_user_func(
 				</span>
 				<?php
 			elseif ( $attributes['showCategory'] ) :
-				$categories = get_the_terms( $post->ID, 'category' );
+				$categories = get_the_category( $post->ID );
 
 				if ( is_array( $categories ) && 0 < count( $categories ) ) :
 					?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some minor tweaks and importer script updates for the GDG migration. Also, because of a bug in some GDG-specific code, the site launched with listing permalinks set without a `listing` URL prefix. Setting an empty prefix is currently impossible in Listings settings UI, so this PR updates the UI to allow such a situation.

Closes #111.

Some background context: originally, the `listings` URL prefix (or a user-defined prefix) was a requirement to avoid potential conflicts with other plugins' permalink settings. Specifically, The Events Calendar uses `events` as the permalink slug for their Events CPT, so the Newspack Listings Events CPT with a permalink slug of `events` would have the same permalink structure as TEC post types, meaning permalinks for one or the other post type would always 404.

However, because of the bug that GDG launched with, Listings CPTs don't have a permalink prefix. Rather than make them update all of their permalinks I thought it'd be best to allow this to reflect the new reality. (GDG doesn't use TEC anyway.) So now it's possible for site admins to define no listings URL prefix, and for listing CPT permalinks to conflict with other post type permalinks, but it also provides more freedom since a lot of publishers would prefer to have no `listings` prefix and simply choose CPT slugs that won't conflict with other permalink structures on their particular sites. Something to keep in mind if such a conflict occurs in the future.

### How to test the changes in this Pull Request:

I don't expect functional testing of the `includes/importer/class-newspack-listings-importer.php` file because it's so site-specific, so a cursory peek at that file's changes should suffice. To test the permalink settings:

1. In **WP Admin > Listings > Settings**, note the default permalink slug settings:

<img width="861" alt="Screen Shot 2021-09-03 at 3 01 55 PM" src="https://user-images.githubusercontent.com/2230142/132064985-188a8a15-3dc3-442a-b075-2ce538b85fa8.png">

2. Visit **WP Admin > Listings > Places** (or another listings post type) and verify that the permalinks all contain the prefixed URL slugs as defined in settings. e.g. for default settings, a Place post should have a permalink like `https://<site_url>/listings/places/<post_slug>`. Also confirm that the permalinks correctly resolve to each singular listing post.

3. Update the settings to new non-empty values. Confirm that the permalinks shown in the WP admin UI are updated to reflect the new settings, and that the new permalinks continue to resolve correctly to each singular listing post.

4. Update the **Listings permalink prefix** setting to an empty value, and attempt to update the other post type slugs to empty values, and save. Confirm that the **Listings permalink prefix** setting is allowed to be empty, but the other slug settings revert back to the default slugs if you try to clear them out.

5. Confirm that the permalinks in WP Admin UI reflect the empty prefix setting and post type slug. e.g. a Place post should have a permalink like `https://<site_url>/places/<post_slug>` (no `listings` prefix). Confirm that the permalinks shown in the WP admin UI are updated to reflect the new settings, and that the new permalinks continue to resolve correctly to each singular listing post. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
