### PR TITLE
feat(ugc): automated WC products for self-serve listings

### DIFF
--- a/includes/class-newspack-listings-products.php
+++ b/includes/class-newspack-listings-products.php
@@ -83,7 +83,7 @@ final class Newspack_Listings_Products {
 		$product_id = get_option( self::NEWSPACK_LISTINGS_PRODUCT_OPTION, false );
 		if ( ! $product_id ) {
 			$settings     = Settings::get_settings();
-			$product_name = __( 'Self-Service Listings', 'newspack-listings' );
+			$product_name = __( 'Self-Serve Listings', 'newspack-listings' );
 
 			// Parent product.
 			$parent_product = new \WC_Product_Grouped();
@@ -96,7 +96,7 @@ final class Newspack_Listings_Products {
 			// Single listing product.
 			$single_product = new \WC_Product_Simple();
 			/* translators: %s: Product name */
-			$single_product->set_name( sprintf( __( '%s: Single Marketplace Listing', 'newspack-listings' ), $product_name ) );
+			$single_product->set_name( sprintf( __( '%s: Single Listing', 'newspack-listings' ), $product_name ) );
 			$single_product->set_regular_price( $settings['newspack_listings_single_price'] );
 			$single_product->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_single_price' );
 			$single_product->set_virtual( true );
@@ -120,7 +120,7 @@ final class Newspack_Listings_Products {
 			// Monthly subscription product.
 			$monthly_product = new \WC_Product_Subscription();
 			/* translators: %s: Product name */
-			$monthly_product->set_name( sprintf( __( '%s: Monthly Business Subscription', 'newspack-listings' ), $product_name ) );
+			$monthly_product->set_name( sprintf( __( '%s: Monthly Subscription', 'newspack-listings' ), $product_name ) );
 			$monthly_product->set_regular_price( $settings['newspack_listings_subscription_price'] );
 			$monthly_product->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_subscription_price' );
 			$monthly_product->update_meta_data( '_subscription_price', wc_format_decimal( $settings['newspack_listings_subscription_price'] ) );

--- a/includes/class-newspack-listings-products.php
+++ b/includes/class-newspack-listings-products.php
@@ -105,17 +105,17 @@ final class Newspack_Listings_Products {
 			$single_product->set_sold_individually( true );
 			$single_product->save();
 
-			// Single "featured" listing add-on.
-			$featured_addon_single = new \WC_Product_Simple();
+			// Single "featured" listing upgrade.
+			$featured_upgrade_single = new \WC_Product_Simple();
 			/* translators: %s: Product name */
-			$featured_addon_single->set_name( sprintf( __( '%s: “Featured” Listing Add-On', 'newspack-listings' ), $product_name ) );
-			$featured_addon_single->set_regular_price( $settings['newspack_listings_featured_add_on'] );
-			$featured_addon_single->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_featured_add_on' );
-			$featured_addon_single->set_virtual( true );
-			$featured_addon_single->set_downloadable( true );
-			$featured_addon_single->set_catalog_visibility( 'hidden' );
-			$featured_addon_single->set_sold_individually( true );
-			$featured_addon_single->save();
+			$featured_upgrade_single->set_name( sprintf( __( '%s: “Featured” Listing Upgrade', 'newspack-listings' ), $product_name ) );
+			$featured_upgrade_single->set_regular_price( $settings['newspack_listings_featured_add_on'] );
+			$featured_upgrade_single->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_featured_add_on' );
+			$featured_upgrade_single->set_virtual( true );
+			$featured_upgrade_single->set_downloadable( true );
+			$featured_upgrade_single->set_catalog_visibility( 'hidden' );
+			$featured_upgrade_single->set_sold_individually( true );
+			$featured_upgrade_single->save();
 
 			// Monthly subscription product.
 			$monthly_product = new \WC_Product_Subscription();
@@ -132,43 +132,43 @@ final class Newspack_Listings_Products {
 			$monthly_product->set_sold_individually( true );
 			$monthly_product->save();
 
-			// Monthly "featured" listing add-on.
-			$featured_addon_monthly = new \WC_Product_Subscription();
+			// Monthly "featured" listing upgrade.
+			$featured_upgrade_monthly = new \WC_Product_Subscription();
 			/* translators: %s: Product name */
-			$featured_addon_monthly->set_name( sprintf( __( '%s: “Featured” Listing Add-On (subscription)', 'newspack-listings' ), $product_name ) );
-			$featured_addon_monthly->set_regular_price( $settings['newspack_listings_featured_add_on'] );
-			$featured_addon_monthly->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_featured_add_on' );
-			$featured_addon_monthly->update_meta_data( '_subscription_price', wc_format_decimal( $settings['newspack_listings_featured_add_on'] ) );
-			$featured_addon_monthly->update_meta_data( '_subscription_period', 'month' );
-			$featured_addon_monthly->update_meta_data( '_subscription_period_interval', 1 );
-			$featured_addon_monthly->set_virtual( true );
-			$featured_addon_monthly->set_downloadable( true );
-			$featured_addon_monthly->set_catalog_visibility( 'hidden' );
-			$featured_addon_monthly->set_sold_individually( true );
-			$featured_addon_monthly->save();
+			$featured_upgrade_monthly->set_name( sprintf( __( '%s: “Featured” Listing Upgrade (subscription)', 'newspack-listings' ), $product_name ) );
+			$featured_upgrade_monthly->set_regular_price( $settings['newspack_listings_featured_add_on'] );
+			$featured_upgrade_monthly->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_featured_add_on' );
+			$featured_upgrade_monthly->update_meta_data( '_subscription_price', wc_format_decimal( $settings['newspack_listings_featured_add_on'] ) );
+			$featured_upgrade_monthly->update_meta_data( '_subscription_period', 'month' );
+			$featured_upgrade_monthly->update_meta_data( '_subscription_period_interval', 1 );
+			$featured_upgrade_monthly->set_virtual( true );
+			$featured_upgrade_monthly->set_downloadable( true );
+			$featured_upgrade_monthly->set_catalog_visibility( 'hidden' );
+			$featured_upgrade_monthly->set_sold_individually( true );
+			$featured_upgrade_monthly->save();
 
-			// Monthly "premium subscription" add-on.
-			$premium_addon_monthly = new \WC_Product_Subscription();
+			// Monthly "premium subscription" upgrade.
+			$premium_upgrade_monthly = new \WC_Product_Subscription();
 			/* translators: %s: Product name */
-			$premium_addon_monthly->set_name( sprintf( __( '%s: Premium Subscription Add-On', 'newspack-listings' ), $product_name ) );
-			$premium_addon_monthly->set_regular_price( $settings['newspack_listings_premium_subscription_add_on'] );
-			$premium_addon_monthly->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_premium_subscription_add_on' );
-			$premium_addon_monthly->update_meta_data( '_subscription_price', wc_format_decimal( $settings['newspack_listings_premium_subscription_add_on'] ) );
-			$premium_addon_monthly->update_meta_data( '_subscription_period', 'month' );
-			$premium_addon_monthly->update_meta_data( '_subscription_period_interval', 1 );
-			$premium_addon_monthly->set_virtual( true );
-			$premium_addon_monthly->set_downloadable( true );
-			$premium_addon_monthly->set_catalog_visibility( 'hidden' );
-			$premium_addon_monthly->set_sold_individually( true );
-			$premium_addon_monthly->save();
+			$premium_upgrade_monthly->set_name( sprintf( __( '%s: Premium Subscription Upgrade', 'newspack-listings' ), $product_name ) );
+			$premium_upgrade_monthly->set_regular_price( $settings['newspack_listings_premium_subscription_add_on'] );
+			$premium_upgrade_monthly->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_premium_subscription_add_on' );
+			$premium_upgrade_monthly->update_meta_data( '_subscription_price', wc_format_decimal( $settings['newspack_listings_premium_subscription_add_on'] ) );
+			$premium_upgrade_monthly->update_meta_data( '_subscription_period', 'month' );
+			$premium_upgrade_monthly->update_meta_data( '_subscription_period_interval', 1 );
+			$premium_upgrade_monthly->set_virtual( true );
+			$premium_upgrade_monthly->set_downloadable( true );
+			$premium_upgrade_monthly->set_catalog_visibility( 'hidden' );
+			$premium_upgrade_monthly->set_sold_individually( true );
+			$premium_upgrade_monthly->save();
 
 			$parent_product->set_children(
 				[
 					$single_product->get_id(),
-					$featured_addon_single->get_id(),
+					$featured_upgrade_single->get_id(),
 					$monthly_product->get_id(),
-					$featured_addon_monthly->get_id(),
-					$premium_addon_monthly->get_id(),
+					$featured_upgrade_monthly->get_id(),
+					$premium_upgrade_monthly->get_id(),
 				]
 			);
 			$parent_product->save();

--- a/includes/class-newspack-listings-products.php
+++ b/includes/class-newspack-listings-products.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Newspack Listings - Sets up WooCommerce products for self-serve listings.
+ *
+ * @package Newspack_Listings
+ */
+
+namespace Newspack_Listings;
+
+use \Newspack_Listings\Newspack_Listings_Settings as Settings;
+use \Newspack_Listings\Newspack_Listings_Core as Core;
+use \Newspack_Listings\Utils as Utils;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Products class.
+ * Sets up WooCommerce products for listings.
+ */
+final class Newspack_Listings_Products {
+
+	/**
+	 * The option name for the product ID.
+	 */
+	const NEWSPACK_LISTINGS_PRODUCT_OPTION = 'newspack_listings_product_id';
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var Newspack_Listings_Products
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Is WooCommerce active? If not, we can't use any of its functionality.
+	 *
+	 * @var $wc_is_active
+	 */
+	protected static $wc_is_active = false;
+
+	/**
+	 * Main Newspack_Listings_Products instance.
+	 * Ensures only one instance of Newspack_Listings_Products is loaded or can be loaded.
+	 *
+	 * @return Newspack_Listings_Products - Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', [ __CLASS__, 'init' ] );
+
+		// When product settings are updated, make sure to update the corresponding WooCommerce products as well.
+		add_action( 'update_option', [ __CLASS__, 'update_products' ], 10, 3 );
+	}
+
+	/**
+	 * After WP init.
+	 */
+	public static function init() {
+		// Check whether WooCommerce is active and available.
+		if ( class_exists( 'WooCommerce' ) ) {
+			self::$wc_is_active = true;
+			self::create_products();
+		}
+	}
+
+	/**
+	 * Create the WooCommerce products for self-serve listings.
+	 */
+	public static function create_products() {
+		if ( ! self::$wc_is_active ) {
+			return false;
+		}
+
+		$product_id = get_option( self::NEWSPACK_LISTINGS_PRODUCT_OPTION, false );
+		if ( ! $product_id ) {
+			$settings     = Settings::get_settings();
+			$product_name = __( 'Self-Service Listings', 'newspack-listings' );
+
+			// Parent product.
+			$parent_product = new \WC_Product_Grouped();
+			$parent_product->set_name( $product_name );
+			$parent_product->set_catalog_visibility( 'hidden' );
+			$parent_product->set_virtual( true );
+			$parent_product->set_downloadable( true );
+			$parent_product->set_sold_individually( true );
+
+			// Single listing product.
+			$single_product = new \WC_Product_Simple();
+			/* translators: %s: Product name */
+			$single_product->set_name( sprintf( __( '%s: Single Marketplace Listing', 'newspack-listings' ), $product_name ) );
+			$single_product->set_regular_price( $settings['newspack_listings_single_price'] );
+			$single_product->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_single_price' );
+			$single_product->set_virtual( true );
+			$single_product->set_downloadable( true );
+			$single_product->set_catalog_visibility( 'hidden' );
+			$single_product->set_sold_individually( true );
+			$single_product->save();
+
+			// Single "featured" listing add-on.
+			$featured_addon_single = new \WC_Product_Simple();
+			/* translators: %s: Product name */
+			$featured_addon_single->set_name( sprintf( __( '%s: “Featured” Listing Add-On', 'newspack-listings' ), $product_name ) );
+			$featured_addon_single->set_regular_price( $settings['newspack_listings_featured_add_on'] );
+			$featured_addon_single->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_featured_add_on' );
+			$featured_addon_single->set_virtual( true );
+			$featured_addon_single->set_downloadable( true );
+			$featured_addon_single->set_catalog_visibility( 'hidden' );
+			$featured_addon_single->set_sold_individually( true );
+			$featured_addon_single->save();
+
+			// Monthly subscription product.
+			$monthly_product = new \WC_Product_Subscription();
+			/* translators: %s: Product name */
+			$monthly_product->set_name( sprintf( __( '%s: Monthly Business Subscription', 'newspack-listings' ), $product_name ) );
+			$monthly_product->set_regular_price( $settings['newspack_listings_subscription_price'] );
+			$monthly_product->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_subscription_price' );
+			$monthly_product->update_meta_data( '_subscription_price', wc_format_decimal( $settings['newspack_listings_subscription_price'] ) );
+			$monthly_product->update_meta_data( '_subscription_period', 'month' );
+			$monthly_product->update_meta_data( '_subscription_period_interval', 1 );
+			$monthly_product->set_virtual( true );
+			$monthly_product->set_downloadable( true );
+			$monthly_product->set_catalog_visibility( 'hidden' );
+			$monthly_product->set_sold_individually( true );
+			$monthly_product->save();
+
+			// Monthly "featured" listing add-on.
+			$featured_addon_monthly = new \WC_Product_Subscription();
+			/* translators: %s: Product name */
+			$featured_addon_monthly->set_name( sprintf( __( '%s: “Featured” Listing Add-On (subscription)', 'newspack-listings' ), $product_name ) );
+			$featured_addon_monthly->set_regular_price( $settings['newspack_listings_featured_add_on'] );
+			$featured_addon_monthly->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_featured_add_on' );
+			$featured_addon_monthly->update_meta_data( '_subscription_price', wc_format_decimal( $settings['newspack_listings_featured_add_on'] ) );
+			$featured_addon_monthly->update_meta_data( '_subscription_period', 'month' );
+			$featured_addon_monthly->update_meta_data( '_subscription_period_interval', 1 );
+			$featured_addon_monthly->set_virtual( true );
+			$featured_addon_monthly->set_downloadable( true );
+			$featured_addon_monthly->set_catalog_visibility( 'hidden' );
+			$featured_addon_monthly->set_sold_individually( true );
+			$featured_addon_monthly->save();
+
+			// Monthly "premium subscription" add-on.
+			$premium_addon_monthly = new \WC_Product_Subscription();
+			/* translators: %s: Product name */
+			$premium_addon_monthly->set_name( sprintf( __( '%s: Premium Subscription Add-On', 'newspack-listings' ), $product_name ) );
+			$premium_addon_monthly->set_regular_price( $settings['newspack_listings_premium_subscription_add_on'] );
+			$premium_addon_monthly->update_meta_data( '_newspack_listings_product_slug', 'newspack_listings_premium_subscription_add_on' );
+			$premium_addon_monthly->update_meta_data( '_subscription_price', wc_format_decimal( $settings['newspack_listings_premium_subscription_add_on'] ) );
+			$premium_addon_monthly->update_meta_data( '_subscription_period', 'month' );
+			$premium_addon_monthly->update_meta_data( '_subscription_period_interval', 1 );
+			$premium_addon_monthly->set_virtual( true );
+			$premium_addon_monthly->set_downloadable( true );
+			$premium_addon_monthly->set_catalog_visibility( 'hidden' );
+			$premium_addon_monthly->set_sold_individually( true );
+			$premium_addon_monthly->save();
+
+			$parent_product->set_children(
+				[
+					$single_product->get_id(),
+					$featured_addon_single->get_id(),
+					$monthly_product->get_id(),
+					$featured_addon_monthly->get_id(),
+					$premium_addon_monthly->get_id(),
+				]
+			);
+			$parent_product->save();
+			update_option( self::NEWSPACK_LISTINGS_PRODUCT_OPTION, $parent_product->get_id() );
+		}
+	}
+
+	/**
+	 * When Newspack Listing settings are updated, update the corresopnding WC products as well.
+	 *
+	 * @param string $option Name of the option to update.
+	 * @param mixed  $old_value The old option value.
+	 * @param mixed  $new_value The new option value.
+	 */
+	public static function update_products( $option, $old_value, $new_value ) {
+		if ( ! self::$wc_is_active ) {
+			return false;
+		}
+
+		// Only if the updated option is a Newspack Listing setting.
+		$settings = Settings::get_settings();
+		if ( ! in_array( $option, array_keys( $settings ) ) ) {
+			return;
+		}
+
+		$product_id = get_option( self::NEWSPACK_LISTINGS_PRODUCT_OPTION, false );
+		if ( $product_id ) {
+			$parent_product = \wc_get_product( $product_id );
+			$parent_product->set_status( 'publish' );
+			$parent_product->save();
+
+			foreach ( $parent_product->get_children() as $child_id ) {
+				$child_product = \wc_get_product( $child_id );
+
+				if ( ! $child_product ) {
+					continue;
+				}
+
+				$settings_slug = $child_product->get_meta( '_newspack_listings_product_slug' );
+				if ( $option === $settings_slug ) {
+					// Set base price.
+					$child_product->set_regular_price( $new_value );
+
+					// Set subscription price, if applicable.
+					if ( 'subscription' === $child_product->get_type() ) {
+						$child_product->update_meta_data( '_subscription_price', \wc_format_decimal( $new_value ) );
+					}
+
+					$child_product->save();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get the WooCommerce product for the parent listings product.
+	 */
+	public static function get_products() {
+		if ( ! self::$wc_is_active ) {
+			return false;
+		}
+
+		$product_id = get_option( self::NEWSPACK_LISTINGS_PRODUCT_OPTION, false );
+		$product    = \wc_get_product( $product_id );
+
+		if ( ! $product || ! $product->is_type( 'grouped' ) ) {
+			return false;
+		}
+
+		return $product;
+	}
+}
+
+Newspack_Listings_Products::instance();

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -23,12 +23,43 @@ final class Newspack_Listings_Settings {
 	}
 
 	/**
+	 * Get settings sections.
+	 */
+	public static function get_sections() {
+		$sections = [
+			'url'     => [
+				'slug'  => 'newspack_listings_url_settings',
+				'title' => __( 'Permalink Settings', 'newspack-listings' ),
+			],
+			'meta'    => [
+				'slug'  => 'newspack_listings_meta_settings',
+				'title' => __( 'Post Meta Settings', 'newspack-listings' ),
+			],
+			'related' => [
+				'slug'  => 'newspack_listings_related_settings',
+				'title' => __( 'Related Content Settings', 'newspack-listings' ),
+			],
+		];
+
+		// Product settings are only relevant if WooCommerce is available.
+		if ( class_exists( 'WooCommerce' ) && defined( 'NEWSPACK_LISTINGS_DEV_MODE' ) && NEWSPACK_LISTINGS_DEV_MODE ) {
+			$sections['product'] = [
+				'slug'  => 'newspack_listings_product_settings',
+				'title' => __( 'Self Service Settings', 'newspack-listings' ),
+			];
+		}
+
+		return $sections;
+	}
+
+	/**
 	 * Default values for site-wide settings.
 	 *
 	 * @return array Array of default settings.
 	 */
 	public static function get_default_settings() {
-		return [
+		$sections = self::get_sections();
+		$settings = [
 			[
 				'description' => __( 'The URL prefix for all listings. This prefix will appear before the listing slug in all listing URLs.', 'newspack-listings' ),
 				'key'         => 'newspack_listings_permalink_prefix',
@@ -36,6 +67,7 @@ final class Newspack_Listings_Settings {
 				'type'        => 'input',
 				'value'       => __( 'listings', 'newspack-listings' ),
 				'allow_empty' => true,
+				'section'     => $sections['url']['slug'],
 			],
 			[
 				'description' => __( 'The URL slug for event listings.', 'newspack-listings' ),
@@ -43,6 +75,7 @@ final class Newspack_Listings_Settings {
 				'label'       => __( 'Event listings slug', 'newspack-listings' ),
 				'type'        => 'input',
 				'value'       => __( 'events', 'newspack-listings' ),
+				'section'     => $sections['url']['slug'],
 			],
 			[
 				'description' => __( 'The URL slug for generic listings.', 'newspack-listings' ),
@@ -50,6 +83,7 @@ final class Newspack_Listings_Settings {
 				'label'       => __( 'Generic listings slug', 'newspack-listings' ),
 				'type'        => 'input',
 				'value'       => __( 'items', 'newspack-listings' ),
+				'section'     => $sections['url']['slug'],
 			],
 			[
 				'description' => __( 'The URL slug for marketplace listings.', 'newspack-listings' ),
@@ -57,6 +91,7 @@ final class Newspack_Listings_Settings {
 				'label'       => __( 'Marketplace listings slug', 'newspack-listings' ),
 				'type'        => 'input',
 				'value'       => __( 'marketplace', 'newspack-listings' ),
+				'section'     => $sections['url']['slug'],
 			],
 			[
 				'description' => __( 'The URL slug for place listings.', 'newspack-listings' ),
@@ -64,6 +99,7 @@ final class Newspack_Listings_Settings {
 				'label'       => __( 'Place listings slug', 'newspack-listings' ),
 				'type'        => 'input',
 				'value'       => __( 'places', 'newspack-listings' ),
+				'section'     => $sections['url']['slug'],
 			],
 			[
 				'description' => __( 'This setting can be overridden per listing.', 'newspack-listings' ),
@@ -71,6 +107,7 @@ final class Newspack_Listings_Settings {
 				'label'       => __( 'Hide authors for listings by default', 'newpack-listings' ),
 				'type'        => 'checkbox',
 				'value'       => true,
+				'section'     => $sections['meta']['slug'],
 			],
 			[
 				'description' => __( 'This setting can be overridden per listing.', 'newspack-listings' ),
@@ -78,6 +115,7 @@ final class Newspack_Listings_Settings {
 				'label'       => __( 'Hide publish and updated dates for listings by default', 'newpack-listings' ),
 				'type'        => 'checkbox',
 				'value'       => true,
+				'section'     => $sections['meta']['slug'],
 			],
 			[
 				'description' => __( 'This setting can be overridden per listing, post, or page.', 'newspack-listings' ),
@@ -85,6 +123,7 @@ final class Newspack_Listings_Settings {
 				'label'       => __( 'Hide parent listings by default', 'newpack-listings' ),
 				'type'        => 'checkbox',
 				'value'       => false,
+				'section'     => $sections['related']['slug'],
 			],
 			[
 				'description' => __( 'This setting can be overridden per listing, post, or page.', 'newspack-listings' ),
@@ -92,8 +131,59 @@ final class Newspack_Listings_Settings {
 				'label'       => __( 'Hide child listings by default', 'newpack-listings' ),
 				'type'        => 'checkbox',
 				'value'       => false,
+				'section'     => $sections['related']['slug'],
 			],
 		];
+
+		// Product settings are only relevant if WooCommerce is available.
+		if ( class_exists( 'WooCommerce' ) && defined( 'NEWSPACK_LISTINGS_DEV_MODE' ) && NEWSPACK_LISTINGS_DEV_MODE ) {
+			$product_settings = [
+				[
+					'description' => __( 'If turned off, any user-generated listings that were previously published will no longer be publicly visible.', 'newspack-listings' ),
+					'key'         => 'newspack_listings_self_service_enabled',
+					'label'       => __( 'Enable self-service listings', 'newpack-listings' ),
+					'type'        => 'checkbox',
+					'value'       => false,
+					'section'     => $sections['product']['slug'],
+				],
+				[
+					'description' => __( 'The base price for a single Marketplace or Event listing (no subscription).', 'newspack-listings' ),
+					'key'         => 'newspack_listings_single_price',
+					'label'       => __( 'Single listing price', 'newpack-listings' ),
+					'type'        => 'number',
+					'value'       => 25,
+					'section'     => $sections['product']['slug'],
+				],
+				[
+					'description' => __( 'The base monthly subscription price for a Place listing.', 'newspack-listings' ),
+					'key'         => 'newspack_listings_subscription_price',
+					'label'       => __( 'Monthly subscription listing price', 'newpack-listings' ),
+					'type'        => 'number',
+					'value'       => 50,
+					'section'     => $sections['product']['slug'],
+				],
+				[
+					'description' => __( 'The add-on price to make the primary listing "featured." For subscription listings, this fee is charged monthly.', 'newspack-listings' ),
+					'key'         => 'newspack_listings_featured_add_on',
+					'label'       => __( 'Add-on: Featured listing price', 'newpack-listings' ),
+					'type'        => 'number',
+					'value'       => 75,
+					'section'     => $sections['product']['slug'],
+				],
+				[
+					'description' => __( 'The add-on price for a premium subscription, which allows subscribers to create up to 5 featured Marketplace or Event listings per month. This fee is charged monthly.', 'newspack-listings' ),
+					'key'         => 'newspack_listings_premium_subscription_add_on',
+					'label'       => __( 'Add-on: Premium subscription price', 'newpack-listings' ),
+					'type'        => 'number',
+					'value'       => 100,
+					'section'     => $sections['product']['slug'],
+				],
+			];
+
+			$settings = array_merge( $settings, $product_settings );
+		}
+
+		return $settings;
 	}
 
 	/**
@@ -155,12 +245,12 @@ final class Newspack_Listings_Settings {
 	 * Register and add settings
 	 */
 	public static function page_init() {
-		add_settings_section(
-			'newspack_listings_options_group',
-			null,
-			null,
-			'newspack-listings-settings-admin'
-		);
+		$sections = self::get_sections();
+
+		foreach ( $sections as $section ) {
+			add_settings_section( $section['slug'], $section['title'], null, 'newspack-listings-settings-admin' );
+		}
+
 		foreach ( self::get_default_settings() as $setting ) {
 			register_setting(
 				'newspack_listings_options_group',
@@ -171,7 +261,7 @@ final class Newspack_Listings_Settings {
 				$setting['label'],
 				[ __CLASS__, 'newspack_listings_settings_callback' ],
 				'newspack-listings-settings-admin',
-				'newspack_listings_options_group',
+				$setting['section'],
 				$setting
 			);
 
@@ -199,6 +289,18 @@ final class Newspack_Listings_Settings {
 				esc_attr( $key ),
 				esc_attr( $key ),
 				! empty( $value ) ? 'checked' : '',
+				esc_attr( $key ),
+				esc_html( $setting['description'] )
+			);
+		} elseif ( 'number' === $type ) {
+			if ( empty( $value ) && empty( $setting['allow_empty'] ) ) {
+				$value = $setting['value'];
+			}
+			printf(
+				'<input type="number" id="%s" name="%s" value="%s" class="small-text" /><p class="description" for="%s">%s</p>',
+				esc_attr( $key ),
+				esc_attr( $key ),
+				esc_attr( $value ),
 				esc_attr( $key ),
 				esc_html( $setting['description'] )
 			);

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -141,13 +141,13 @@ final class Newspack_Listings_Settings {
 				[
 					'description' => __( 'If turned off, any user-generated listings that were previously published will no longer be publicly visible.', 'newspack-listings' ),
 					'key'         => 'newspack_listings_self_service_enabled',
-					'label'       => __( 'Enable self-service listings', 'newpack-listings' ),
+					'label'       => __( 'Enable self-serve listings', 'newpack-listings' ),
 					'type'        => 'checkbox',
 					'value'       => false,
 					'section'     => $sections['product']['slug'],
 				],
 				[
-					'description' => __( 'The base price for a single Marketplace or Event listing (no subscription).', 'newspack-listings' ),
+					'description' => __( 'The base price for a single listing (no subscription). Single listings expire after 30 days.', 'newspack-listings' ),
 					'key'         => 'newspack_listings_single_price',
 					'label'       => __( 'Single listing price', 'newpack-listings' ),
 					'type'        => 'number',
@@ -155,7 +155,7 @@ final class Newspack_Listings_Settings {
 					'section'     => $sections['product']['slug'],
 				],
 				[
-					'description' => __( 'The base monthly subscription price for a Place listing.', 'newspack-listings' ),
+					'description' => __( 'The base monthly subscription price. This fee is charged monthly.', 'newspack-listings' ),
 					'key'         => 'newspack_listings_subscription_price',
 					'label'       => __( 'Monthly subscription listing price', 'newpack-listings' ),
 					'type'        => 'number',
@@ -171,7 +171,7 @@ final class Newspack_Listings_Settings {
 					'section'     => $sections['product']['slug'],
 				],
 				[
-					'description' => __( 'The add-on price for a premium subscription, which allows subscribers to create up to 5 featured Marketplace or Event listings per month. This fee is charged monthly.', 'newspack-listings' ),
+					'description' => __( 'The add-on price for a premium subscription, which allows subscribers to create up to 5 featured listings linked to the primary listing per month. This fee is charged monthly.', 'newspack-listings' ),
 					'key'         => 'newspack_listings_premium_subscription_add_on',
 					'label'       => __( 'Add-on: Premium subscription price', 'newpack-listings' ),
 					'type'        => 'number',

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -45,7 +45,7 @@ final class Newspack_Listings_Settings {
 		if ( class_exists( 'WooCommerce' ) && defined( 'NEWSPACK_LISTINGS_DEV_MODE' ) && NEWSPACK_LISTINGS_DEV_MODE ) {
 			$sections['product'] = [
 				'slug'  => 'newspack_listings_product_settings',
-				'title' => __( 'Self Service Settings', 'newspack-listings' ),
+				'title' => __( 'Self-Serve Settings', 'newspack-listings' ),
 			];
 		}
 

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -42,7 +42,7 @@ final class Newspack_Listings_Settings {
 		];
 
 		// Product settings are only relevant if WooCommerce is available.
-		if ( class_exists( 'WooCommerce' ) && defined( 'NEWSPACK_LISTINGS_DEV_MODE' ) && NEWSPACK_LISTINGS_DEV_MODE ) {
+		if ( class_exists( 'WooCommerce' ) && defined( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED' ) && NEWSPACK_LISTINGS_SELF_SERVE_ENABLED ) {
 			$sections['product'] = [
 				'slug'  => 'newspack_listings_product_settings',
 				'title' => __( 'Self-Serve Settings', 'newspack-listings' ),
@@ -136,7 +136,7 @@ final class Newspack_Listings_Settings {
 		];
 
 		// Product settings are only relevant if WooCommerce is available.
-		if ( class_exists( 'WooCommerce' ) && defined( 'NEWSPACK_LISTINGS_DEV_MODE' ) && NEWSPACK_LISTINGS_DEV_MODE ) {
+		if ( class_exists( 'WooCommerce' ) && defined( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED' ) && NEWSPACK_LISTINGS_SELF_SERVE_ENABLED ) {
 			$product_settings = [
 				[
 					'description' => __( 'If turned off, any user-generated listings that were previously published will no longer be publicly visible.', 'newspack-listings' ),
@@ -163,17 +163,17 @@ final class Newspack_Listings_Settings {
 					'section'     => $sections['product']['slug'],
 				],
 				[
-					'description' => __( 'The add-on price to make the primary listing "featured." For subscription listings, this fee is charged monthly.', 'newspack-listings' ),
+					'description' => __( 'The upgrade price to make the primary listing "featured." For subscription listings, this fee is charged monthly.', 'newspack-listings' ),
 					'key'         => 'newspack_listings_featured_add_on',
-					'label'       => __( 'Add-on: Featured listing price', 'newpack-listings' ),
+					'label'       => __( 'Upgrade: Featured listing price', 'newpack-listings' ),
 					'type'        => 'number',
 					'value'       => 75,
 					'section'     => $sections['product']['slug'],
 				],
 				[
-					'description' => __( 'The add-on price for a premium subscription, which allows subscribers to create up to 5 featured listings linked to the primary listing per month. This fee is charged monthly.', 'newspack-listings' ),
+					'description' => __( 'The upgrade price for a premium subscription, which allows subscribers to create up to 5 featured listings linked to the primary listing per month. This fee is charged monthly.', 'newspack-listings' ),
 					'key'         => 'newspack_listings_premium_subscription_add_on',
-					'label'       => __( 'Add-on: Premium subscription price', 'newpack-listings' ),
+					'label'       => __( 'Upgrade: Premium subscription price', 'newpack-listings' ),
 					'type'        => 'number',
 					'value'       => 100,
 					'section'     => $sections['product']['slug'],

--- a/newspack-listings.php
+++ b/newspack-listings.php
@@ -33,7 +33,7 @@ require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/class-newspack-listings-
 require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/class-newspack-listings-api.php';
 
 // Enable experimental/in-progress self-serve listings functionality.
-if ( defined( 'NEWSPACK_LISTINGS_DEV_MODE' ) && NEWSPACK_LISTINGS_DEV_MODE ) {
+if ( defined( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED' ) && NEWSPACK_LISTINGS_SELF_SERVE_ENABLED ) {
 	require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/class-newspack-listings-products.php';
 }
 

--- a/newspack-listings.php
+++ b/newspack-listings.php
@@ -32,6 +32,11 @@ require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/class-newspack-listings-
 require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/class-newspack-listings-taxonomies.php';
 require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/class-newspack-listings-api.php';
 
+// Enable experimental/in-progress self-serve listings functionality.
+if ( defined( 'NEWSPACK_LISTINGS_DEV_MODE' ) && NEWSPACK_LISTINGS_DEV_MODE ) {
+	require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/class-newspack-listings-products.php';
+}
+
 // CLI importer files.
 require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/importer/newspack-listings-importer-utils.php';
 require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/importer/class-newspack-listings-importer.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Takes the first step toward self-serve listings with some automated WooCommerce products to help facilitate single purchase or subscription-based listings.

The following products are included to start, but all of these are subject to change based on publisher feedback. The default prices and planned behavior are also subject to change pending publisher feedback.

* **Single Listing:** Users can purchase a single listing of any type (Event, Generic, Marketplace, or Place).
  - **Intended behavior (not yet implemented):** Once a user purchases a single listing, they can edit their listing in the block editor and submit it for editorial review. Once approved and published by a staff member, the listing is live for 30 days. If they want to extend the life of the listing, the user can purchase another single listing and resubmit the same listing or create a new listing, or purchase a subscription.
* **Monthly Subscription:** Users can purchase a monthly subscription. This entitles the user to a single listing of any type which will be live for the duration of the subscription.
  - **Intended behavior (not yet implemented):** The subscription should have a minimum purchase period of 6 months (or 1 year?). The single listing tied to their subscription purchase is considered the user's "primary" listing. They may make purchases of single listings during their subscription to publish additional listings which will remain live during the subscription period. These listings are associated with the primary listing via the Related Content feature.
* **Add-on: Featured Listing:** This is an optional add-on which can be applied to either a single listing or a subscription at the point of purchase only.
  - **Intended behavior (not yet implemented):** Purchasing this will apply "featured" status to the primary listing item created during checkout. The Featured status will remain as long as the primary listing is live. For subscriptions, this will charge an additional monthly fee for the duration of the subscription.
* **Add-on: Premium Subscription:** This is an optional add-on which can be applied to a subscription.
  - **Intended behavior (not yet implemented):** This product will let the subscriber create up to five (subject to change) additional listings of any type per month of active subscription, all of which are associated with the user's primary listing via Related Content, and all of which will receive Featured status for 30 days after publishing.

**Note:** Taking a cue from the long/ongoing projects in Newspack Plugin, I'm going to start pushing smaller, partial functionality to `master` for the larger self-serve/UGC listings milestone. Because it's incomplete and not fully tested, this functionality will be gated behind a WP config constant `NEWSPACK_LISTINGS_DEV_MODE`, so unless this constant is defined and true, these PRs shouldn't behave any differently compared to `master`.

### How to test the changes in this Pull Request:

1. After checking out this branch, plugin behavior at first should be unchanged from `master`.
2. Ensure you have WooCommerce and its Subscriptions extension active.
3. Add `define( 'NEWSPACK_LISTINGS_DEV_MODE', true );` to your `wp-config.php`. 
4. After adding the environment constant, visit the Products menu in WP admin.
5. Confirm that the following products have been automatically generated by the plugin:

<img width="517" alt="Screen Shot 2021-09-10 at 2 50 49 PM" src="https://user-images.githubusercontent.com/2230142/132916231-630b28bb-a383-4af4-96bc-89cba0ef15e3.png">

6. Go to **Listings > Settings** in WP admin. Confirm that the settings page is now divided into several sections, with a new "Self-Serve Listings" section at the bottom:

<img width="1364" alt="Screen Shot 2021-09-10 at 2 44 40 PM" src="https://user-images.githubusercontent.com/2230142/132915557-abfa080c-3611-412b-9283-ce72335b1f68.png">

7. Update the price values of these settings and save. Confirm that in the WooCommerce Products menu, the prices of each product is automatically updated to match Listings plugin settings.
8. Temporarily deactivate WooCommerce and confirm that the Listings plugin continues to work, but without the additional "Self-Serve Listings" settings. Note that the Listings products will not be deleted if the Listings or WC plugins are deactivated, so that we don't lose purchase histories in that event.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
