### PR TITLE
feat: add new setting to disable Jetpack Related Posts module

### DIFF
--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -74,6 +74,7 @@ final class Newspack_Listings_Core {
 		add_filter( 'newspack_listings_hide_publish_date', [ __CLASS__, 'hide_publish_date' ] );
 		add_filter( 'newspack_theme_featured_image_post_types', [ __CLASS__, 'support_featured_image_options' ] );
 		add_filter( 'newspack_sponsors_post_types', [ __CLASS__, 'support_newspack_sponsors' ] );
+		add_filter( 'jetpack_relatedposts_filter_options', [ __CLASS__, 'disable_jetpack_related_posts' ] );
 		register_activation_hook( NEWSPACK_LISTINGS_FILE, [ __CLASS__, 'activation_hook' ] );
 	}
 
@@ -732,6 +733,22 @@ final class Newspack_Listings_Core {
 			$post_types,
 			array_values( self::NEWSPACK_LISTINGS_POST_TYPES )
 		);
+	}
+
+	/**
+	 * Disable Jetpack Related Posts on singular listng posts.
+	 *
+	 * @param array $options Options array for Jetpack Related Posts.
+	 * @return array Filtered options array.
+	 */
+	public static function disable_jetpack_related_posts( $options ) {
+		$disable_jetpack_related_posts = Settings::get_settings( 'newspack_listings_hide_jetpack_related_posts' );
+
+		if ( is_singular( array_values( self::NEWSPACK_LISTINGS_POST_TYPES ) ) && ! empty( $disable_jetpack_related_posts ) ) {
+			$options['enabled'] = false;
+		}
+
+		return $options;
 	}
 
 	/**

--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -75,6 +75,7 @@ final class Newspack_Listings_Core {
 		add_filter( 'newspack_theme_featured_image_post_types', [ __CLASS__, 'support_featured_image_options' ] );
 		add_filter( 'newspack_sponsors_post_types', [ __CLASS__, 'support_newspack_sponsors' ] );
 		add_filter( 'jetpack_relatedposts_filter_options', [ __CLASS__, 'disable_jetpack_related_posts' ] );
+		add_filter( 'jetpack_related_posts_customize_options', [ __CLASS__, 'disable_jetpack_related_posts_customizer' ] );
 		register_activation_hook( NEWSPACK_LISTINGS_FILE, [ __CLASS__, 'activation_hook' ] );
 	}
 
@@ -746,6 +747,24 @@ final class Newspack_Listings_Core {
 
 		if ( is_singular( array_values( self::NEWSPACK_LISTINGS_POST_TYPES ) ) && ! empty( $disable_jetpack_related_posts ) ) {
 			$options['enabled'] = false;
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Disable Jetpack Related Posts Customizer UI on listing posts.
+	 *
+	 * @param array $options Array of options used to display Related Posts in the Customizer.
+	 *
+	 * @return array Filtered array of options.
+	 */
+	public static function disable_jetpack_related_posts_customizer( $options ) {
+		$disable_jetpack_related_posts = Settings::get_settings( 'newspack_listings_hide_jetpack_related_posts' );
+
+		// If previewing a singular listing and Related Posts is disabled via Listing settings, don't show the Related Posts UI in Customizer.
+		if ( is_singular( array_values( self::NEWSPACK_LISTINGS_POST_TYPES ) ) && ! empty( $disable_jetpack_related_posts ) ) {
+			$options['msg_go_to_single']['active_callback'] = '__return_true';
 		}
 
 		return $options;

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -135,6 +135,18 @@ final class Newspack_Listings_Settings {
 			],
 		];
 
+		// If Related Posts is on, show the setting to hide it.
+		if ( true || class_exists( 'Jetpack_RelatedPosts' ) ) {
+			$settings[] = [
+				'description' => __( 'Hide <a href="/wp-admin/admin.php?page=jetpack#/traffic">Jetpack’s Related Posts module</a> on individual listing pages.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_hide_jetpack_related_posts',
+				'label'       => __( 'Hide Jetpack Related Posts module', 'newpack-listings' ),
+				'type'        => 'checkbox',
+				'value'       => true,
+				'section'     => $sections['related']['slug'],
+			];
+		}
+
 		// Product settings are only relevant if WooCommerce is available.
 		if ( class_exists( 'WooCommerce' ) && defined( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED' ) && NEWSPACK_LISTINGS_SELF_SERVE_ENABLED ) {
 			$product_settings = [
@@ -192,7 +204,8 @@ final class Newspack_Listings_Settings {
 	 * @param string|null $option (Optional) Key name of a single setting to get. If not given, will return all settings.
 	 * @param boolean     $get_default (Optional) If true, return the default value.
 	 *
-	 * @return array|boolean Array of current site-wide settings, or false if returning a single option with no value.
+	 * @return array|boolean|WP_Error Array of current site-wide settings, false if returning a single option with no value,
+	 *                                or WP_Error if given a key name that doesn't match a registered settings field.
 	 */
 	public static function get_settings( $option = null, $get_default = false ) {
 		$defaults = self::get_default_settings();
@@ -201,7 +214,7 @@ final class Newspack_Listings_Settings {
 			$defaults,
 			function( $acc, $setting ) use ( $get_default ) {
 				$key   = $setting['key'];
-				$value = $get_default ? $setting['value'] : get_option( $key, '' );
+				$value = $get_default ? $setting['value'] : get_option( $key, $setting['value'] );
 
 				// Guard against empty strings, which can happen if an option is set and then unset.
 				if ( empty( $setting['allow_empty'] ) && '' === $value && 'checkbox' !== $setting['type'] ) {
@@ -214,8 +227,15 @@ final class Newspack_Listings_Settings {
 			[]
 		);
 
-		// If passed an option key name, just give that option.
+		// If passed an option key name, just give that option. If the option doesn't exist, return a WP Error.
 		if ( ! empty( $option ) ) {
+			if ( ! isset( $settings[ $option ] ) ) {
+				return new \WP_Error(
+					'newspack_listings_invalid_settings_key',
+					/* translators: %s: Settings key being requested */
+					sprintf( __( 'The settings key “%s” does not exist.', 'newspack-listings' ), $option )
+				);
+			}
 			return $settings[ $option ];
 		}
 
@@ -290,7 +310,7 @@ final class Newspack_Listings_Settings {
 				esc_attr( $key ),
 				! empty( $value ) ? 'checked' : '',
 				esc_attr( $key ),
-				esc_html( $setting['description'] )
+				wp_kses_post( $setting['description'] )
 			);
 		} elseif ( 'number' === $type ) {
 			if ( empty( $value ) && empty( $setting['allow_empty'] ) ) {
@@ -302,7 +322,7 @@ final class Newspack_Listings_Settings {
 				esc_attr( $key ),
 				esc_attr( $value ),
 				esc_attr( $key ),
-				esc_html( $setting['description'] )
+				wp_kses_post( $setting['description'] )
 			);
 		} else {
 			if ( empty( $value ) && empty( $setting['allow_empty'] ) ) {
@@ -314,7 +334,7 @@ final class Newspack_Listings_Settings {
 				esc_attr( $key ),
 				esc_attr( $value ),
 				esc_attr( $key ),
-				esc_html( $setting['description'] )
+				wp_kses_post( $setting['description'] )
 			);
 		}
 	}

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -136,7 +136,7 @@ final class Newspack_Listings_Settings {
 		];
 
 		// If Related Posts is on, show the setting to hide it.
-		if ( true || class_exists( 'Jetpack_RelatedPosts' ) ) {
+		if ( class_exists( 'Jetpack_RelatedPosts' ) ) {
 			$settings[] = [
 				'description' => __( 'Hide <a href="/wp-admin/admin.php?page=jetpack#/traffic">Jetpack’s Related Posts module</a> on individual listing pages.', 'newspack-listings' ),
 				'key'         => 'newspack_listings_hide_jetpack_related_posts',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a new setting to optionally prevent the Jetpack Related Posts module from appearing on singular listings. This is turned on by default as it's been a very common request from publishers.

Closes #115.

### How to test the changes in this Pull Request:

This is a hard feature to test because you need a site that is connected to and has been fully indexed by Jetpack (basically, a true production site). The Related Posts module also needs to have been turned on for some time after that before it will start appearing on the site. DM me if you're having trouble finding a suitable site to test with.

1. On `master`, on a site which is displaying the Related Posts module, observe that the module appears on singular posts of all types, including listings.
2. Check out this branch; go to **Listings > Settings**. Confirm there's a new option under the "Related Content" heading, which is enabled by default (note that this option is only displayed if the Jetpack Related Posts module is active):

<img width="651" alt="Screen Shot 2021-09-13 at 4 42 32 PM" src="https://user-images.githubusercontent.com/2230142/133165772-dad41514-2a88-4daf-837b-38abbae0a87b.png">

3. Confirm that while the option is enabled, the Related Posts module no longer appears on singular listings, but continues to appear on all other singular post types.
4. Confirm that if you turn the option off, the Related Posts module appears again on singular listings.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
