### PR TITLE
feat: feature extensions from gdg

### DIFF
--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -74,6 +74,7 @@ final class Newspack_Listings_Core {
 		add_filter( 'newspack_listings_hide_publish_date', [ __CLASS__, 'hide_publish_date' ] );
 		add_filter( 'newspack_theme_featured_image_post_types', [ __CLASS__, 'support_featured_image_options' ] );
 		add_filter( 'newspack_sponsors_post_types', [ __CLASS__, 'support_newspack_sponsors' ] );
+		add_filter( 'wpseo_primary_term_taxonomies', [ $this, 'disable_yoast_primary_categories' ], 10, 2 );
 		register_activation_hook( NEWSPACK_LISTINGS_FILE, [ __CLASS__, 'activation_hook' ] );
 	}
 
@@ -732,6 +733,23 @@ final class Newspack_Listings_Core {
 			$post_types,
 			array_values( self::NEWSPACK_LISTINGS_POST_TYPES )
 		);
+	}
+
+	/**
+	 * Disable the Yoast primary category picker for Listing CPTs.
+	 *
+	 * @param array  $taxonomies Array of taxonomies.
+	 * @param string $post_type Post type of the current post.
+	 */
+	public function disable_yoast_primary_categories( $taxonomies, $post_type ) {
+		$disable_yoast = Settings::get_settings( 'newspack_listings_disable_yoast_primary_categories' );
+
+		// Disable for all taxonomies on Listing CPTs.
+		if ( ! is_wp_error( $disable_yoast ) && ! empty( $disable_yoast ) && self::is_listing() ) {
+			return [];
+		}
+
+		return $taxonomies;
 	}
 
 	/**

--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -147,7 +147,7 @@ final class Newspack_Listings_Core {
 		$settings          = Settings::get_settings();
 		$prefix            = $settings['newspack_listings_permalink_prefix'];
 		$prefix            = ! empty( $prefix ) ? $prefix . '/' : '';
-		$show_in_archives  = ! empty( $settings['newspack_listings_enable_archives'] ) ? true : false;
+		$show_in_archives  = ! empty( $settings['newspack_listings_enable_post_type_archives'] ) ? true : false;
 		$default_config    = [
 			'has_archive'  => $show_in_archives,
 			'public'       => true,
@@ -778,7 +778,7 @@ final class Newspack_Listings_Core {
 	 * @param WP_Query $query Query.
 	 */
 	public static function enable_listing_category_archives( $query ) {
-		$show_in_archives = Settings::get_settings( 'newspack_listings_enable_archives' );
+		$show_in_archives = Settings::get_settings( 'newspack_listings_enable_term_archives' );
 
 		// Only if archives are enabled in Settings.
 		if ( empty( $show_in_archives ) ) {

--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -704,17 +704,7 @@ final class Newspack_Listings_Core {
 
 		// If an archive.
 		if ( is_post_type_archive( $listing_post_types ) || is_category() || is_tag() ) {
-			global $wp_query;
-
-			// If all of the items in the first set of results are listings, assume it's a listings-only archive.
-			$is_all_listings = true;
-
-			foreach ( $wp_query->posts as $post ) {
-				if ( ! in_array( $post->post_type, $listing_post_types ) ) {
-					$is_all_listings = false;
-				}
-			}
-
+			$is_all_listings = Utils\all_posts_are_type( $listing_post_types );
 			if ( $is_all_listings ) {
 				$classes[] = 'newspack-listings';
 

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -118,6 +118,14 @@ final class Newspack_Listings_Settings {
 				'section'     => $sections['meta']['slug'],
 			],
 			[
+				'description' => __( 'Disables Yoast primary category functionality for all listings.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_disable_yoast_primary_categories',
+				'label'       => __( 'Disable Yoast primary categories', 'newpack-listings' ),
+				'type'        => 'checkbox',
+				'value'       => false,
+				'section'     => $sections['meta']['slug'],
+			],
+			[
 				'description' => __( 'This setting can be overridden per listing, post, or page.', 'newspack-listings' ),
 				'key'         => 'newspack_listings_hide_parents',
 				'label'       => __( 'Hide parent listings by default', 'newpack-listings' ),

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -294,7 +294,7 @@ final class Newspack_Listings_Settings {
 			);
 
 			// Flush permalinks when permalink option is updated.
-			$is_permalink_option = preg_match( '/newspack_listings_(.*)(_prefix|_slug)/', $setting['key'] );
+			$is_permalink_option = preg_match( '/newspack_listings_(.*)(_prefix|_slug)/', $setting['key'] ) || 'newspack_listings_enable_archives' === $setting['key'];
 			if ( $is_permalink_option ) {
 				add_action( 'update_option_' . $setting['key'], [ __CLASS__, 'flush_permalinks' ], 10, 3 );
 			}

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -106,9 +106,17 @@ final class Newspack_Listings_Settings {
 				'section'     => $sections['url']['slug'],
 			],
 			[
-				'description' => __( 'Allows listings to appear in automated category, tag, and post type archives.', 'newspack-listings' ),
-				'key'         => 'newspack_listings_enable_archives',
-				'label'       => __( 'Enable listing archives', 'newpack-listings' ),
+				'description' => __( 'Enables automated archives for each listing type. Archives will use the permalink slugs set above.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_enable_post_type_archives',
+				'label'       => __( 'Enable listing type archives', 'newpack-listings' ),
+				'type'        => 'checkbox',
+				'value'       => false,
+				'section'     => $sections['directory']['slug'],
+			],
+			[
+				'description' => __( 'Allows listings to appear in automated category and tag archives.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_enable_term_archives',
+				'label'       => __( 'Enable listing category/tag archives', 'newpack-listings' ),
 				'type'        => 'checkbox',
 				'value'       => false,
 				'section'     => $sections['directory']['slug'],
@@ -294,7 +302,7 @@ final class Newspack_Listings_Settings {
 			);
 
 			// Flush permalinks when permalink option is updated.
-			$is_permalink_option = preg_match( '/newspack_listings_(.*)(_prefix|_slug)/', $setting['key'] ) || 'newspack_listings_enable_archives' === $setting['key'];
+			$is_permalink_option = preg_match( '/newspack_listings_(.*)(_prefix|_slug|_archives)/', $setting['key'] );
 			if ( $is_permalink_option ) {
 				add_action( 'update_option_' . $setting['key'], [ __CLASS__, 'flush_permalinks' ], 10, 3 );
 			}

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -31,6 +31,10 @@ final class Newspack_Listings_Settings {
 				'slug'  => 'newspack_listings_url_settings',
 				'title' => __( 'Permalink Settings', 'newspack-listings' ),
 			],
+			'directory' => [
+				'slug'  => 'newspack_listings_directory_settings',
+				'title' => __( 'Automated Directory Settings', 'newspack-listings' ),
+			],
 			'meta'      => [
 				'slug'  => 'newspack_listings_meta_settings',
 				'title' => __( 'Post Meta Settings', 'newspack-listings' ),
@@ -38,10 +42,6 @@ final class Newspack_Listings_Settings {
 			'related'   => [
 				'slug'  => 'newspack_listings_related_settings',
 				'title' => __( 'Related Content Settings', 'newspack-listings' ),
-			],
-			'directory' => [
-				'slug'  => 'newspack_listings_directory_settings',
-				'title' => __( 'Automated Directory Settings', 'newspack-listings' ),
 			],
 		];
 
@@ -106,6 +106,22 @@ final class Newspack_Listings_Settings {
 				'section'     => $sections['url']['slug'],
 			],
 			[
+				'description' => __( 'Allows listings to appear in automated category, tag, and post type archives.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_enable_archives',
+				'label'       => __( 'Enable listing archives', 'newpack-listings' ),
+				'type'        => 'checkbox',
+				'value'       => false,
+				'section'     => $sections['directory']['slug'],
+			],
+			[
+				'description' => __( 'If listing archives are enabled, shows listings-only archives in a grid-like layout.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_archive_grid',
+				'label'       => __( 'Show listing archives as grid', 'newpack-listings' ),
+				'type'        => 'checkbox',
+				'value'       => false,
+				'section'     => $sections['directory']['slug'],
+			],
+			[
 				'description' => __( 'This setting can be overridden per listing.', 'newspack-listings' ),
 				'key'         => 'newspack_listings_hide_author',
 				'label'       => __( 'Hide authors for listings by default', 'newpack-listings' ),
@@ -144,22 +160,6 @@ final class Newspack_Listings_Settings {
 				'type'        => 'checkbox',
 				'value'       => false,
 				'section'     => $sections['related']['slug'],
-			],
-			[
-				'description' => __( 'Allows listings to appear in automated category, tag, and post type archives.', 'newspack-listings' ),
-				'key'         => 'newspack_listings_enable_archives',
-				'label'       => __( 'Enable listing archives', 'newpack-listings' ),
-				'type'        => 'checkbox',
-				'value'       => false,
-				'section'     => $sections['directory']['slug'],
-			],
-			[
-				'description' => __( 'If listing archives are enabled, shows listings-only archives in a grid-like layout.', 'newspack-listings' ),
-				'key'         => 'newspack_listings_archive_grid',
-				'label'       => __( 'Show listing archives as grid', 'newpack-listings' ),
-				'type'        => 'checkbox',
-				'value'       => false,
-				'section'     => $sections['directory']['slug'],
 			],
 		];
 

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -27,17 +27,21 @@ final class Newspack_Listings_Settings {
 	 */
 	public static function get_sections() {
 		$sections = [
-			'url'     => [
+			'url'       => [
 				'slug'  => 'newspack_listings_url_settings',
 				'title' => __( 'Permalink Settings', 'newspack-listings' ),
 			],
-			'meta'    => [
+			'meta'      => [
 				'slug'  => 'newspack_listings_meta_settings',
 				'title' => __( 'Post Meta Settings', 'newspack-listings' ),
 			],
-			'related' => [
+			'related'   => [
 				'slug'  => 'newspack_listings_related_settings',
 				'title' => __( 'Related Content Settings', 'newspack-listings' ),
+			],
+			'directory' => [
+				'slug'  => 'newspack_listings_directory_settings',
+				'title' => __( 'Automated Directory Settings', 'newspack-listings' ),
 			],
 		];
 
@@ -140,6 +144,22 @@ final class Newspack_Listings_Settings {
 				'type'        => 'checkbox',
 				'value'       => false,
 				'section'     => $sections['related']['slug'],
+			],
+			[
+				'description' => __( 'Allows listings to appear in automated category, tag, and post type archives.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_enable_archives',
+				'label'       => __( 'Enable listing archives', 'newpack-listings' ),
+				'type'        => 'checkbox',
+				'value'       => false,
+				'section'     => $sections['directory']['slug'],
+			],
+			[
+				'description' => __( 'If listing archives are enabled, shows listings-only archives in a grid-like layout.', 'newspack-listings' ),
+				'key'         => 'newspack_listings_archive_grid',
+				'label'       => __( 'Show listing archives as grid', 'newpack-listings' ),
+				'type'        => 'checkbox',
+				'value'       => false,
+				'section'     => $sections['directory']['slug'],
 			],
 		];
 

--- a/includes/newspack-listings-utils.php
+++ b/includes/newspack-listings-utils.php
@@ -424,6 +424,10 @@ function get_term_classes( $post_id = null ) {
 function all_posts_are_type( $post_type = 'post' ) {
 	global $wp_query;
 
+	if ( ! is_array( $post_type ) ) {
+		$post_type = [ $post_type ];
+	}
+
 	// If all of the items in the first set of results match the given type.
 	$matches_type = true;
 

--- a/includes/newspack-listings-utils.php
+++ b/includes/newspack-listings-utils.php
@@ -413,3 +413,25 @@ function get_term_classes( $post_id = null ) {
 		$tag_classes
 	);
 }
+
+/**
+ * Check if all posts in the current loop query are the given post type(s).
+ *
+ * @param string|array $post_type Post type or array of post types to match against.
+ *
+ * @return boolean True if all posts are of the given type(s).
+ */
+function all_posts_are_type( $post_type = 'post' ) {
+	global $wp_query;
+
+	// If all of the items in the first set of results match the given type.
+	$matches_type = true;
+
+	foreach ( $wp_query->posts as $post ) {
+		if ( ! in_array( $post->post_type, $post_type ) ) {
+			$matches_type = false;
+		}
+	}
+
+	return $matches_type;
+}

--- a/src/assets/front-end/archives.scss
+++ b/src/assets/front-end/archives.scss
@@ -1,0 +1,56 @@
+/* Directory Archives */
+.archive.newspack-listings-grid {
+	#main {
+		align-content: flex-start;
+		display: flex;
+		flex-wrap: wrap;
+
+		@media ( min-width: 600px ) {
+			margin-left: -1rem;
+			margin-right: -1rem;
+		}
+		@media ( min-width: 782px ) {
+			width: calc( 65% + 40px );
+		}
+	}
+
+	.navigation.pagination {
+		width: 100%;
+	}
+
+	.site-main > article {
+		display: block;
+		margin: 0 0 3rem;
+		position: relative;
+		width: 100%;
+
+		.listing-label {
+			position: absolute;
+			top: -0.5rem;
+		}
+
+		.entry-title {
+			font-size: 0.75rem;
+			text-transform: uppercase;
+		}
+
+		@media ( min-width: 600px ) {
+			border: 1rem solid transparent;
+			flex: 1 0 50%;
+			max-width: 50%;
+		}
+		@media ( min-width: 1200px ) {
+			flex: 1 0 33%;
+			max-width: 33%;
+		}
+	}
+
+	.has-post-thumbnail .post-thumbnail {
+		margin-bottom: 0.5rem;
+		max-width: 100%;
+
+		img {
+			object-position: 0 0;
+		}
+	}
+}

--- a/src/assets/front-end/view.scss
+++ b/src/assets/front-end/view.scss
@@ -1,3 +1,4 @@
+@import './archives';
 @import './curated-list';
 @import './event';
 @import './listing';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ports some of the lower-risk feature enhancements developed for GDG back into the main Listings plugin. These new features are gated behind new settings so that sites that are already using Listings won't see any unexpected behavior.

I'd also like to port the "featured listing" functionality from GDG, but I'm awaiting some feedback on https://github.com/Automattic/newspack-gdg/issues/1 before we do so as it may impact performance in the current state.

### How to test the changes in this Pull Request:

#### Yoast primary categories

1. Check out this branch; go to **Listings > Settings**.
2. Observe a new setting under the "Post Meta Settings" heading, disabled by default:

<img width="628" alt="Screen Shot 2021-09-14 at 12 11 29 PM" src="https://user-images.githubusercontent.com/2230142/133311133-6c40dbeb-0300-4ae0-9eb4-5ac922a89940.png">

3. Enable it and save. Edit any listing and expand the "Categories" sidebar, and confirm that you can no longer choose a primary category.

#### Listing archives

1. Check out this branch; ensure that category/tag archives don't contain listing posts and list post type archives (with slugs as defined in Listings > Settings) 404, as these features haven't been explicitly enabled yet.
2. Go to **Listings > Settings** and observe some new settings under a "Directory Settings" heading (both should be disabled by default):

<img width="767" alt="Screen Shot 2021-09-14 at 11 57 09 AM" src="https://user-images.githubusercontent.com/2230142/133309295-faa4cea4-4adc-424e-9d71-8b90a5cfde33.png">

3. Enable the first option, "Enable listing archives." Note that permalinks should be flushed automatically if you change this setting.
4. Make sure you have some listings published and assigned a.) a category/tag that is shared by other non-listing posts, and b.) a category/tag that is assigned only to listings
5. Visit the term archives for the categories/tags assigned to your listings. Confirm that listing posts now appear in these archives, alongside other post types if the term is shared. The styles at this point should be identical to regular WP archives.
6. Visit the post type archives for a listing (e.g. default slug for places: `/listings/places/`). Confirm that these now work as well.
7. Go back to **Listings > Settings** and enable the second new option, "Show listing archives as grid".
8. Refresh the category/tag archive for the term that is only applied to listings (no other post types). Confirm that the items are laid out in a grid at larger viewports. This option only applies to archive pages when every item is a listing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
