### PR TITLE
fix: fatal error when WooCommerce Subscriptions is not active

### DIFF
--- a/includes/class-newspack-listings-products.php
+++ b/includes/class-newspack-listings-products.php
@@ -66,7 +66,7 @@ final class Newspack_Listings_Products {
 	 */
 	public static function init() {
 		// Check whether WooCommerce is active and available.
-		if ( class_exists( 'WooCommerce' ) ) {
+		if ( class_exists( 'WooCommerce' ) && class_exists( 'WC_Subscriptions_Product' ) ) {
 			self::$wc_is_active = true;
 			self::create_products();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a fatal error with dire consequences, triggered by certain conditions.

Closes #121.

### How to test the changes in this Pull Request:

1. On `master`, set `define( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED', true );` in your wp-config.php file.
2. Install and activate WooCommerce, but not WooCommerce Subscriptions (disable this latter plugin if already installed and active).
3. Refresh the site and observe a fatal error which prevents the entire site from loading—admin and front-end! 😱 
4. Check out this branch, confirm that the fatal is avoided and that the Self-Serve Listings features are only enabled if both WooCommerce and WooCommerce Subscriptions are active.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
