### PR TITLE
fix: editor crash when switching months in event dates block

### DIFF
--- a/src/blocks/event-dates/edit.js
+++ b/src/blocks/event-dates/edit.js
@@ -6,7 +6,6 @@ import { InspectorControls } from '@wordpress/block-editor';
 import {
 	BaseControl,
 	Button,
-	DatePicker,
 	DateTimePicker,
 	PanelBody,
 	PanelRow,
@@ -18,7 +17,11 @@ import { Fragment } from '@wordpress/element';
 export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 	const { endDate, showEnd, showTime, startDate } = attributes;
 	const { createNotice } = useDispatch( 'core/notices' );
-	const DatePickerComponent = showTime ? DateTimePicker : DatePicker;
+	const classes = [ 'newspack-listings__event-dates' ];
+
+	if ( ! showTime ) {
+		classes.push( 'hide-time' );
+	}
 
 	return (
 		<Fragment>
@@ -49,7 +52,7 @@ export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 				</PanelBody>
 			</InspectorControls>
 
-			<div className="newspack-listings__event-dates">
+			<div className={ classes.join( ' ' ) }>
 				<div className="newspack-listings__event-dates-controls">
 					<BaseControl
 						id={ `event-start-date-${ clientId }` }
@@ -59,10 +62,9 @@ export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 							showTime ? __( 'Time', 'newspack-listings' ) : __( 'Date', 'newspack-listings' )
 						) }
 					>
-						<DatePickerComponent
+						<DateTimePicker
 							currentDate={ startDate ? new Date( startDate ) : null }
 							is12Hour={ true }
-							onMonthPreviewed={ () => {} }
 							onChange={ value => {
 								if (
 									! value || // If clearing the value.
@@ -97,7 +99,7 @@ export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 								showTime ? __( 'Time', 'newspack-listings' ) : __( 'Date', 'newspack-listings' )
 							) }
 						>
-							<DatePickerComponent
+							<DateTimePicker
 								currentDate={ endDate ? new Date( endDate ) : null }
 								is12Hour={ true }
 								onChange={ value => {

--- a/src/blocks/event-dates/editor.scss
+++ b/src/blocks/event-dates/editor.scss
@@ -2,6 +2,12 @@
 @import '../../assets/shared/event';
 
 .newspack-listings {
+	&__event-dates {
+		&.hide-time .components-datetime__time {
+			display: none;
+		}
+	}
+
 	&__event-dates-controls {
 		display: flex;
 		flex-wrap: wrap;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a crash in the `DatePicker` component that was [introduced in WP 5.8](https://github.com/WordPress/gutenberg/pull/29716). It's been [fixed in the Gutenberg plugin](https://github.com/WordPress/gutenberg/pull/31751) but apparently not yet in WP Core. This fix avoids the use of `DatePicker` and uses `DateTimePicker` (which isn't affected by this bug) even when not using times in the block.

### How to test the changes in this Pull Request:

1. Ensure your test site is running WP 5.8+ but NOT the Gutenberg plugin.
2. On `master`, create an Event listing. In the Event Date block, **disable** "Show Times" and **enable** "Show End Date".
3. Attempt to change the month of the end date and observe a JS crash: `TypeError: t.onMonthPreviewed is not a function`
4. Check out this branch, repeat steps 1-2, confirm that the crash is avoided and that the event date ranges still render as expected on the front-end based on step 10 in #12.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
