### PR TITLE
feat: featured listing query sorting via custom table instead of post meta

### DIFF
--- a/includes/class-newspack-listings-featured.php
+++ b/includes/class-newspack-listings-featured.php
@@ -314,12 +314,14 @@ final class Newspack_Listings_Featured {
 		global $wpdb;
 		$table_name = self::get_table_name();
 
-		$clauses['join']   .= "
-			LEFT JOIN {$table_name}
-			ON (
-				{$wpdb->prefix}posts.ID = {$table_name}.post_id
-			) ";
-		$clauses['orderby'] = "{$table_name}.feature_priority DESC, " . $clauses['orderby'];
+		if ( false === strpos( $clauses['join'], "LEFT JOIN {$table_name}" ) ) {
+			$clauses['join']   .= "
+				LEFT JOIN {$table_name}
+				ON (
+					{$wpdb->prefix}posts.ID = {$table_name}.post_id
+				) ";
+			$clauses['orderby'] = "{$table_name}.feature_priority DESC, " . $clauses['orderby'];
+		}
 
 		return $clauses;
 	}

--- a/includes/class-newspack-listings-featured.php
+++ b/includes/class-newspack-listings-featured.php
@@ -86,6 +86,7 @@ final class Newspack_Listings_Featured {
 			$sql             = "CREATE TABLE IF NOT EXISTS $table_name (
 				-- Post ID.
 				post_id bigint(20) unsigned NOT NULL,
+				-- Feature priority: 1–9 if featured, 0 if not.
 				feature_priority int(1) unsigned NOT NULL,
 				PRIMARY KEY (post_id),
 				KEY (feature_priority),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

An experimental, alternative solution to re-sorting post queries to show featured listings in descending order of priority number before other posts. This branch creates a custom DB table with just two columns: `post_id` and `feature_priority`. On post save, if the post is featured, the feature priority meta value is copied to a row with the same value, keyed to the post's ID. If it's not featured, any rows matching the post's ID in the custom table are deleted, which should hopefully keep the table lean. On post query, matching rows are appended to the main posts query using a `LEFT JOIN` statement and then used as a sorting criterion. The theory is that this _should_ be more performant than using post meta to sort the query, but I'm not 100% certain it is, hence the experimental nature of the PR.

### How to test the changes in this Pull Request:

Publish some listings with the Featured Listing toggle ON and make sure to update (since the custom table rows are created upon post save). After that, same testing instructions as #124.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
