### PR TITLE
fix: prevent shadow taxonomies from being editable via quick edit

### DIFF
--- a/includes/class-newspack-listings-taxonomies.php
+++ b/includes/class-newspack-listings-taxonomies.php
@@ -67,6 +67,16 @@ final class Newspack_Listings_Taxonomies {
 	 * @return object Config options for all shadow taxonomies.
 	 */
 	public static function get_shadow_taxonomy_config() {
+		$default_config = [
+			'hierarchical'       => true,
+			'public'             => true,
+			'show_in_menu'       => false, // Set to 'true' to show in WP admin for debugging purposes.
+			'show_in_quick_edit' => false,
+			'show_in_rest'       => true,
+			'show_tagcloud'      => false,
+			'show_ui'            => true,
+		];
+
 		return [
 			'event'       => [
 				'post_types' => [
@@ -75,16 +85,13 @@ final class Newspack_Listings_Taxonomies {
 					Core::NEWSPACK_LISTINGS_POST_TYPES['event'],
 					Core::NEWSPACK_LISTINGS_POST_TYPES['generic'],
 				],
-				'config'     => [
-					'hierarchical'  => true,
-					'public'        => true,
-					'rewrite'       => [ 'slug' => self::NEWSPACK_LISTINGS_TAXONOMIES['event'] ],
-					'show_in_menu'  => false, // Set to 'true' to show in WP admin for debugging purposes.
-					'show_in_rest'  => true,
-					'show_tagcloud' => false,
-					'show_ui'       => true,
-					'labels'        => get_post_type_object( Core::NEWSPACK_LISTINGS_POST_TYPES['event'] )->labels,
-				],
+				'config'     => wp_parse_args(
+					[
+						'rewrite' => [ 'slug' => self::NEWSPACK_LISTINGS_TAXONOMIES['event'] ],
+						'labels'  => get_post_type_object( Core::NEWSPACK_LISTINGS_POST_TYPES['event'] )->labels,
+					],
+					$default_config
+				),
 			],
 			'generic'     => [
 				'post_types' => [
@@ -92,16 +99,13 @@ final class Newspack_Listings_Taxonomies {
 					'page',
 					Core::NEWSPACK_LISTINGS_POST_TYPES['generic'],
 				],
-				'config'     => [
-					'hierarchical'  => true,
-					'public'        => true,
-					'rewrite'       => [ 'slug' => self::NEWSPACK_LISTINGS_TAXONOMIES['event'] ],
-					'show_in_menu'  => false, // Set to 'true' to show in WP admin for debugging purposes.
-					'show_in_rest'  => true,
-					'show_tagcloud' => false,
-					'show_ui'       => true,
-					'labels'        => get_post_type_object( Core::NEWSPACK_LISTINGS_POST_TYPES['generic'] )->labels,
-				],
+				'config'     => wp_parse_args(
+					[
+						'rewrite' => [ 'slug' => self::NEWSPACK_LISTINGS_TAXONOMIES['generic'] ],
+						'labels'  => get_post_type_object( Core::NEWSPACK_LISTINGS_POST_TYPES['generic'] )->labels,
+					],
+					$default_config
+				),
 			],
 			'marketplace' => [
 				'post_types' => [
@@ -110,16 +114,13 @@ final class Newspack_Listings_Taxonomies {
 					Core::NEWSPACK_LISTINGS_POST_TYPES['generic'],
 					Core::NEWSPACK_LISTINGS_POST_TYPES['marketplace'],
 				],
-				'config'     => [
-					'hierarchical'  => true,
-					'public'        => true,
-					'rewrite'       => [ 'slug' => self::NEWSPACK_LISTINGS_TAXONOMIES['marketplace'] ],
-					'show_in_menu'  => false, // Set to 'true' to show in WP admin for debugging purposes.
-					'show_in_rest'  => true,
-					'show_tagcloud' => false,
-					'show_ui'       => true,
-					'labels'        => get_post_type_object( Core::NEWSPACK_LISTINGS_POST_TYPES['marketplace'] )->labels,
-				],
+				'config'     => wp_parse_args(
+					[
+						'rewrite' => [ 'slug' => self::NEWSPACK_LISTINGS_TAXONOMIES['marketplace'] ],
+						'labels'  => get_post_type_object( Core::NEWSPACK_LISTINGS_POST_TYPES['marketplace'] )->labels,
+					],
+					$default_config
+				),
 			],
 			'place'       => [
 				'post_types' => [
@@ -130,16 +131,13 @@ final class Newspack_Listings_Taxonomies {
 					Core::NEWSPACK_LISTINGS_POST_TYPES['marketplace'],
 					Core::NEWSPACK_LISTINGS_POST_TYPES['place'],
 				],
-				'config'     => [
-					'hierarchical'  => true,
-					'public'        => true,
-					'rewrite'       => [ 'slug' => self::NEWSPACK_LISTINGS_TAXONOMIES['place'] ],
-					'show_in_menu'  => false, // Set to 'true' to show in WP admin for debugging purposes.
-					'show_in_rest'  => true,
-					'show_tagcloud' => false,
-					'show_ui'       => true,
-					'labels'        => get_post_type_object( Core::NEWSPACK_LISTINGS_POST_TYPES['place'] )->labels,
-				],
+				'config'     => wp_parse_args(
+					[
+						'rewrite' => [ 'slug' => self::NEWSPACK_LISTINGS_TAXONOMIES['place'] ],
+						'labels'  => get_post_type_object( Core::NEWSPACK_LISTINGS_POST_TYPES['place'] )->labels,
+					],
+					$default_config
+				),
 			],
 		];
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Because shadow taxonomies for parent/child listings is managed through a custom UI, they should not be editable from the Quick Edit UI. This PR prevents them from being shown in Quick Edit, and also does some light refactoring to reduce code duplication.

Note that #59 is still unresolved and so parent/child listings still aren't visible on the front-end...

Closes #116.

### How to test the changes in this Pull Request:

1. On `master`, go to a listings post type page (Places, for example) and quick edit a post. Observe that the shadow taxonomies for child listings are shown and editable here.
2. Check out this branch, confirm they're no longer shown in Quick Edit, but that you're still able to add related listings when editing a listing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
