### PR TITLE
feat: add listing post types to supported post types in Campaigns

### DIFF
--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -73,7 +73,8 @@ final class Newspack_Listings_Core {
 		add_filter( 'newspack_listings_hide_author', [ __CLASS__, 'hide_author' ] );
 		add_filter( 'newspack_listings_hide_publish_date', [ __CLASS__, 'hide_publish_date' ] );
 		add_filter( 'newspack_theme_featured_image_post_types', [ __CLASS__, 'support_featured_image_options' ] );
-		add_filter( 'newspack_sponsors_post_types', [ __CLASS__, 'support_newspack_sponsors' ] );
+		add_filter( 'newspack_sponsors_post_types', [ __CLASS__, 'support_listing_post_types' ] );
+		add_filter( 'newspack_campaigns_default_supported_post_types', [ __CLASS__, 'support_listing_post_types' ] );
 		add_filter( 'jetpack_relatedposts_filter_options', [ __CLASS__, 'disable_jetpack_related_posts' ] );
 		add_filter( 'jetpack_related_posts_customize_options', [ __CLASS__, 'disable_jetpack_related_posts_customizer' ] );
 		add_filter( 'wpseo_primary_term_taxonomies', [ __CLASS__, 'disable_yoast_primary_categories' ], 10, 2 );
@@ -852,12 +853,12 @@ final class Newspack_Listings_Core {
 	}
 
 	/**
-	 * If using the Newspack Sponsors plugin, add support for sponsors to all listings.
+	 * For filters from other plugins to allow certain post types, add support for all listing post types.
 	 *
 	 * @param array $post_types Array of supported post types.
 	 * @return array Filtered array of supported post types.
 	 */
-	public static function support_newspack_sponsors( $post_types ) {
+	public static function support_listing_post_types( $post_types ) {
 		return array_merge(
 			$post_types,
 			array_values( self::NEWSPACK_LISTINGS_POST_TYPES )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support for listing post types to Newspack Campaigns. Requires the new filter applied in https://github.com/Automattic/newspack-popups/pull/726 to work.

h/t @kariae for helping me debug.

This doesn't necessarily fix a bug, but it does address some behavior that might be unexpected. Listing post types are displayed in archives, alongside regular posts if they share the same categories, tags, or authors. Newspack Campaigns prompts can be set to display in post archives, but if the archive contains any post type other than `post` and `page`, those extra post types aren't used for determining whether to display the archive prompt. Adding support for listing post types to Campaigns by default seems a reasonable default behavior—editors can now _opt out_ of showing specific prompts on singular listings or archives that contain listings, instead of having to _opt in_ to showing specific prompts in these cases.

### How to test the changes in this Pull Request:

1. Publish a listing of any type and assign it a category so that it shows up as the first post in that category's archive page. 
2. In Newspack Campaigns, publish an archive prompt that should display after 1 post in category archives. Don't edit the Post Types options (but do observe that it shows listing post types, but they're not selected by default).
3. On `master`, observe that the prompt is not displayed on the category archive (because the first post shown is a listing, not a post).
4. Check out this branch, confirm that the archive prompt and any new prompt now have listing post types selected by default.
5. Confirm that the category archive now shows the prompt after the first post.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
