### PR TITLE
fix: minor bugfixes for featured and self-serve listings

### DIFF
--- a/includes/class-newspack-listings-core.php
+++ b/includes/class-newspack-listings-core.php
@@ -841,7 +841,9 @@ final class Newspack_Listings_Core {
 		}
 
 		if ( ! is_admin() && $query->is_main_query() ) {
-			if ( is_category() || is_tag() ) {
+			$archive_should_include_listings = is_category() || is_tag();
+
+			if ( apply_filters( 'newspack_listings_archive_types', $archive_should_include_listings ) ) {
 				$existing_post_types = $query->get( 'post_type' );
 
 				// Don't alter the query for templates.

--- a/includes/class-newspack-listings-featured.php
+++ b/includes/class-newspack-listings-featured.php
@@ -93,6 +93,7 @@ final class Newspack_Listings_Featured {
 		if ( self::TABLE_VERSION !== $current_version ) {
 			self::create_custom_table();
 			self::populate_custom_table();
+			update_option( self::TABLE_VERSION_OPTION, self::TABLE_VERSION );
 		}
 	}
 
@@ -118,8 +119,6 @@ final class Newspack_Listings_Featured {
 
 			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 			dbDelta( $sql ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.dbDelta_dbdelta
-
-			update_option( self::TABLE_VERSION_OPTION, self::TABLE_VERSION );
 		}
 	}
 
@@ -166,7 +165,13 @@ final class Newspack_Listings_Featured {
 				$results       = new \WP_Query( $args );
 
 				foreach ( $results->posts as $featured_listing ) {
-					self::update_priority( $featured_listing->ID, $default_priority );
+					$priority = get_post_meta( $featured_listing->ID, 'newspack_listings_featured_priority', true );
+
+					if ( ! $priority ) {
+						$priority = $default_priority;
+					}
+
+					self::update_priority( $featured_listing->ID, $priority );
 				}
 			}
 		}

--- a/includes/class-newspack-listings-featured.php
+++ b/includes/class-newspack-listings-featured.php
@@ -149,7 +149,13 @@ final class Newspack_Listings_Featured {
 		$default_priority = 5;
 
 		foreach ( $results->posts as $featured_listing ) {
-			self::update_priority( $featured_listing->ID, $default_priority );
+			$priority = get_post_meta( $featured_listing->ID, 'newspack_listings_featured_priority', true );
+
+			if ( ! $priority ) {
+				$priority = $default_priority;
+			}
+
+			self::update_priority( $featured_listing->ID, $priority );
 		}
 
 		// If there were more than 1 page of results, repeat with subsequent pages until all posts are processed.

--- a/includes/class-newspack-listings-settings.php
+++ b/includes/class-newspack-listings-settings.php
@@ -185,7 +185,7 @@ final class Newspack_Listings_Settings {
 		}
 
 		// Product settings are only relevant if WooCommerce is available.
-		if ( class_exists( 'WooCommerce' ) && defined( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED' ) && NEWSPACK_LISTINGS_SELF_SERVE_ENABLED ) {
+		if ( class_exists( 'WooCommerce' ) && class_exists( 'WC_Subscriptions_Product' ) && defined( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED' ) && NEWSPACK_LISTINGS_SELF_SERVE_ENABLED ) {
 			$product_settings = [
 				[
 					'description' => __( 'The base price for a single listing (no subscription).', 'newspack-listings' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two minor bugs related to featured and self-serve listings. Also adds a filter that lets external plugins define whether specific archive pages or other queries should show listing post types.

### How to test the changes in this Pull Request:

#### Featured listing migration

This one is hard to test unless you had the very experimental version of featured listings enabled. But the experimental version used post meta for feature priority, whereas the new treatment uses a custom table value. The plugin migrates featured listings to the custom table, but previously didn't check the priority value—it just set all listings to the default priority.

1. Using WP CLI, simulate the conditions of migrating from a site using the very experimental version of featured listings by adding a meta value to a listing post: `wp post meta update <listing ID> newspack_listings_featured_priority 9` (this sets the meta value to something other than the default value of `5`)
2. Just in case, force the plugin to rebuild the custom table by temporarily bumping the table version number on [this line](https://github.com/Automattic/newspack-listings/blob/master/includes/class-newspack-listings-featured.php#L36). We would normally only do this if we needed to rebuild the table for live sites, but the custom table isn't live on any hosted sites yet as it just got merged.
3. In `wp-config.php`, define `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` as `true`
4. View the listing with the post meta set to `9` in the block editor. In the Featured Listing Settings panel, confirm that the feature priority matches the meta value you previously set.

#### PHP warning

There was a warning being thrown if WooCommerce was installed/active but WooCommerce Subscriptions was not. This was because there was one instance of a check in Newspack Listings Settings that only checked for WC but not Subscriptions.

1. Install/activate WooCommerce, but deactivate/do not install WooCommerce Subscriptions.
2. On `master`, observe a PHP warning on init:

```
PHP Notice:  Undefined index: product in /srv/htdocs/wp-content/plugins/newspack-listings/includes/class-newspack-listings-settings.php on line 221
```

3. Check out this branch, confirm that the warning no longer appears.

#### Archive filter

By default, listing post types can only appear in category or tag term archives. This PR adds a filter to let other plugins define other conditions where listings should be added to the query, such as on custom taxonomy archives or date/author archives.

1. In your theme's `functions.php`, temporarily add a filter like this:

```php
add_filter(
	'newspack_listings_archive_types',
	function( $archive_should_include_listings ) {
		if ( is_author() ) {
			return true;
		}
		
		return $archive_should_include_listings;
	}
);
```

2. View the author archive page for an author that has authored at least one listing, and confirm that listings appear in the archive page.
3. Remove the filter and refresh the author archive. Confirm that the listings no longer appear in any archives other than categories and tags.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
