### PR TITLE
[URGENT] fix: a fatal error when self-serve listings env variable is not defined

### DIFF
--- a/includes/class-newspack-listings-blocks.php
+++ b/includes/class-newspack-listings-blocks.php
@@ -107,13 +107,13 @@ final class Newspack_Listings_Blocks {
 			'self_serve_enabled' => defined( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED' ) && NEWSPACK_LISTINGS_SELF_SERVE_ENABLED,
 		];
 
-		if ( $localized_data['self_serve_enabled'] && class_exists( 'Newspack_Listings\Newspack_Listings_Products' ) ) {
+		if ( $localized_data['self_serve_enabled'] ) {
 			$localized_data['self_serve_listing_types']      = Products::get_listing_types();
 			$localized_data['self_serve_listing_expiration'] = Settings::get_settings( 'newspack_listings_single_purchase_expiration' );
-		}
 
-		if ( Products::is_listing_customer() ) {
-			$localized_data['is_listing_customer'] = true;
+			if ( Products::is_listing_customer() ) {
+				$localized_data['is_listing_customer'] = true;
+			}
 		}
 
 		wp_localize_script(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a fatal error that occurs in the block editor when the `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` environment variable is not defined or not `true`. 😢 

### How to test the changes in this Pull Request:

1. In your `wp-config.php`, define `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` as false or remove the constant entirely from your config.
2. On `master`, observe that any and all block editor pages fail to load with a fatal PHP error.
3. Check out this branch, refresh the editor, confirm that the error no longer occurs.
4. Define `define( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED', true );` in your config and confirm that the editor still works, and that self-serve and featured listing features are now available.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
