### PR TITLE
fix: prevent showing 0 for listings with no categories

### DIFF
--- a/src/blocks/listing/listing.js
+++ b/src/blocks/listing/listing.js
@@ -57,7 +57,7 @@ export const Listing = ( { attributes, error, post } ) => {
 							<span className="flag">{ sponsors[ 0 ].sponsor_flag }</span>
 						</span>
 					) }
-					{ showCategory && category.length && ! sponsors && (
+					{ showCategory && 0 < category.length && ! sponsors && (
 						<div className="cat-links">
 							{ category.map( ( _category, index ) => (
 								<Fragment key="index">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor bug in the editor UI for Curated List blocks. The front-end isn't affected, just the editor. Note: this may or may not require WP 5.9 to replicate.

### How to test the changes in this Pull Request:

1. Publish several listings, some with categories applied and others with no categories.
2. Add a Curated List block to a post and set its query settings to show your listings with and without categories.
3. Enable the "Show Categories" option for the Curated List block.
4. Observe that the listings without any categories display a `0` in place of the category labels:

<img width="438" alt="Screen Shot 2022-01-14 at 10 02 06 AM" src="https://user-images.githubusercontent.com/2230142/149556379-cd4b0572-c71a-49e1-8727-b9750b5d9e2b.png">

5. Check out this block, refresh, confirm that the `0` no longer appears.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
