### PR TITLE
fix(curated-list): when sorting by event date, treat date strings as plain strings

### DIFF
--- a/includes/class-newspack-listings-api.php
+++ b/includes/class-newspack-listings-api.php
@@ -304,9 +304,8 @@ final class Newspack_Listings_Api {
 		}
 		if ( ! empty( $query['sortBy'] ) ) {
 			if ( 'event_date' === $query['sortBy'] ) {
-				$args['orderby']   = 'meta_value';
-				$args['meta_type'] = 'DATE';
-				$args['meta_key']  = 'newspack_listings_event_start_date';
+				$args['orderby']  = 'meta_value';
+				$args['meta_key'] = 'newspack_listings_event_start_date';
 			} else {
 				$args['orderby'] = $query['sortBy'];
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The feature to sort event listings by event date isn't quite working. I believe it's because the query tries to sort by the `newspack_listings_event_start_date` meta value, and treats this meta value as a `dateetime` string. However, this meta field saves datetime strings as plain text strings, e.g. `2022-03-04T17:30:00`. When sorting a curated list block containing events by event date, and multiple events have event dates that start on the same date but at different times, the sorting order isn't always correct—`2022-03-04T17:30:00` ends up being sorted after `2022-03-04T19:15:00` despite being a later time.

This PR updates the query sorting to treat the meta values as plain text so that `2022-03-04T17:30:00` should come before `2022-03-04T19:15:00`.

### How to test the changes in this Pull Request:

1. Publish at least two Event listings containing Event Dates blocks with a start time occurring on the same date, but at different times, e.g. March 4, 2022 @ 5:30pm and March 4, 2022 @ 7:15pm.
2. In another post, add a Curated List block, set to query mode, set the Listing Type to "Events" only, expand "Show Advanced Filters" and sort by Event Date in Ascending order.
3. Observe that in both the editor and on the front-end, the events appear in the wrong order: the 7:15pm event shows before the 5:30pm event.
4. Check out this branch and confirm that in both the editor and on the front-end, the events appear in the correct order.
5. Smoke test multiple events at various dates and times and confirm that all dates are sorted as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
