### PR TITLE
fix: allow customers to access block editor components

### DIFF
--- a/includes/class-newspack-listings-products.php
+++ b/includes/class-newspack-listings-products.php
@@ -1446,6 +1446,29 @@ final class Newspack_Listings_Products {
 	}
 
 	/**
+	 * Given a user ID and post ID, check whether the user owns (is the author of) the post.
+	 *
+	 * @param int|null $user_id ID of the user to check. If not given, will check the current user.
+	 * @param int      $post_id ID of the post to check. Must be a listing post type.
+	 *
+	 * @return boolean True if the user owns the post, false if not.
+	 */
+	public static function does_customer_own_listing( $user_id = null, $post_id = null ) {
+		global $user_ID;
+
+		if ( ! $user_id ) {
+			$user_id = $user_ID;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post || ! Core::is_listing( $post->post_type ) ) {
+			return false;
+		}
+
+		return (int) $post->post_author === (int) $user_id;
+	}
+
+	/**
 	 * When a subscription product is removed from a listing subscription, also unpublish the primary listing, if published.
 	 * WHen an upgrade product is removed from a premium subscription, unset the Featured status of the primary listing.
 	 * Also disallow creation of new related Marketplace listings.
@@ -1550,9 +1573,10 @@ final class Newspack_Listings_Products {
 	 * @return bool[] Filtered array of allowed/disallowed capabilities.
 	 */
 	public static function allow_customers_to_edit_own_posts( $allcaps, $caps, $args ) {
-		$capabilities        = [ 'edit_posts', 'edit_published_posts', 'publish_posts' ];
+		$capabilities        = [ 'edit_post', 'edit_posts', 'edit_published_posts', 'publish_posts' ];
 		$capability          = $args[0];
 		$user_id             = $args[1];
+		$post_id             = isset( $args[2] ) ? $args[2] : null;
 		$is_listing_customer = false;
 
 		if ( in_array( $capability, $capabilities ) && $user_id ) {
@@ -1564,7 +1588,8 @@ final class Newspack_Listings_Products {
 			$is_published   = 'publish' === get_post_status( get_the_ID() );
 			$actions        = [ 'edit', 'editposts' ];
 			$action         = isset( $_REQUEST['action'] ) ? sanitize_text_field( wp_unslash( sanitize_text_field( $_REQUEST['action'] ) ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$is_edit_screen = $action && in_array( $action, $actions );
+			$context        = isset( $_REQUEST['context'] ) ? sanitize_text_field( wp_unslash( sanitize_text_field( $_REQUEST['context'] ) ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$is_edit_screen = ( $action && in_array( $action, $actions, true ) ) || ( $context && in_array( $context, $actions, true ) );
 
 			// If not an edit screen, if the post ID isn't set or isn't in the user's allowed post IDs,
 			// or the user is trying to access an admin page other than the post editor, disallow.
@@ -1575,6 +1600,11 @@ final class Newspack_Listings_Products {
 			// If on the edit screen for a post that has already been published, allow the user to update their published post.
 			if ( 'publish_posts' === $capability ) {
 				$allcaps[ $capability ] = $is_published ? 1 : 0;
+			}
+
+			// As of WP 5.9, some capabilities in the block editor are checked via REST API. e.g. reusable blocks and featured images.
+			if ( 'edit_posts' === $capability && $is_edit_screen ) {
+				$allcaps[ $capability ] = 1;
 			}
 		}
 

--- a/includes/class-newspack-listings-products.php
+++ b/includes/class-newspack-listings-products.php
@@ -1453,7 +1453,7 @@ final class Newspack_Listings_Products {
 	 *
 	 * @return boolean True if the user owns the post, false if not.
 	 */
-	public static function does_customer_own_listing( $user_id = null, $post_id = null ) {
+	public static function does_user_own_listing( $user_id = null, $post_id = null ) {
 		global $user_ID;
 
 		if ( ! $user_id ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In WP 5.9, FSE implements several new capabilities checks in the block editor that gate access to certain block editor features, notably the featured image sidebar panel and reusable blocks inserter. These checks are performed via REST API, so the server `$_REQUEST` params we're currently using to decide whether the user is viewing a block editor page don't apply to these requests. This means that self-serve listing customers currently can't edit or view featured images for their own listings.

However, the capabilities checks via REST API do seem to include a `context` argument, which is either `view` or `edit`. If this argument exists and is `edit`, we can reasonably assume the request is coming from a REST API request to check editor permissions and allow or deny permissions accordingly. This PR allows such capabilities checks to pass so that customer users can access these block editor features when editing posts they've purchased.

This PR also adds a new utility method, `does_customer_own_listing`, which checks whether the given (or current) user owns the given listing. I didn't end up needing to use this for the capabilities check fix above, but I left the method because I can see it being useful for future feature development.

### How to test the changes in this Pull Request:

1. Make sure your site is setup to allow self-serve listings (must have `define( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED', true );` defined and have WooCommerce + WooCommerce Subscriptions installed and active, then place a Self-Serve Listings block on a post or page).
2. As a non-logged-in user, purchase a self-serve listing. After the purchase is complete, edit the listing.
3. On `master`, observe that the sidebar panel for Featured Image never loads, nor does the Reusable Blocks tab in the block inserter. You can also observe in the Dev Tools > Network tab that REST API requests for endpoints such as `blocks` and `themes` fail with error messages like "Sorry, you are not allowed to view the active theme."
4. Check out this branch and refresh the editor. This time confirm that the Featured Image panel and Reusable Blocks UIs are accessible.
5. Try to edit a post not owned by the customer user (hint: by manually pasting in an edit URL with a post ID authored by a different user) and confirm that you're still not able to edit it, nor view any WP admin dashboard page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
