### PR TITLE
fix: separate checks for self-serve vs. featured listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.9.4-hotfix.1](https://github.com/Automattic/newspack-listings/compare/v2.9.3...v2.9.4-hotfix.1) (2022-03-31)
+
+
+### Bug Fixes
+
+* separate checks for self-serve vs. featured listings ([dc20e96](https://github.com/Automattic/newspack-listings/commit/dc20e9672fa59e89b82978a36dd16f153c280913))
+
 ## [2.9.3](https://github.com/Automattic/newspack-listings/compare/v2.9.2...v2.9.3) (2022-03-22)
 
 

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -105,6 +105,7 @@ final class Blocks {
 
 			// Self-serve listings features are gated behind an environment variable.
 			'self_serve_enabled' => Products::is_active(),
+			'featured_enabled'   => Featured::is_active(),
 		];
 
 		if ( Products::is_active() ) {

--- a/newspack-listings.php
+++ b/newspack-listings.php
@@ -7,7 +7,7 @@
  * Author URI:      https://newspack.pub
  * Text Domain:     newspack-listings
  * Domain Path:     /languages
- * Version:         2.9.3
+ * Version:         2.9.4-hotfix.1
  *
  * @package         Newspack_Listings
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-listings",
-  "version": "2.9.3",
+  "version": "2.9.4-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-listings",
-      "version": "2.9.3",
+      "version": "2.9.4-hotfix.1",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "newspack-components": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-listings",
-  "version": "2.9.3",
+  "version": "2.9.4-hotfix.1",
   "description": "",
   "scripts": {
     "cm": "newspack-scripts commit",

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -32,6 +32,7 @@ const {
 	post_types: postTypes,
 	is_listing_customer: isListingCustomer = false,
 	self_serve_enabled: selfServeEnabled,
+	featured_enabled: featuredEnabled,
 } = window?.newspack_listings_data;
 
 /**
@@ -49,7 +50,7 @@ if ( isListing() ) {
 
 		// Register featured listing sidebar.
 		// We don't want to show the Featured Listing UI to customers, otherwise anyone could just make their listings featured.
-		if ( selfServeEnabled && ! isListingCustomer ) {
+		if ( featuredEnabled && ! isListingCustomer ) {
 			registerPlugin( 'newspack-listings-featured', {
 				render: FeaturedListings,
 				icon: null,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#233 simplified the checks to determine whether to allow self-serve and featured listings to be managed in the dashboard, but it perhaps simplified them a bit too much. It's possible that a site might want to use featured listings but not self-serve, in which case they might not need WooCommerce or WooCommerce Subscriptions, which are prerequisites for self-serve but not featured listings. This PR restores the separate checks for each so that featured listings can still be used even if those plugins aren't active.

### How to test the changes in this Pull Request:

1. On your test site, disable WooCommerce and/or WooCommerce Subscriptions. Set `define( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED', true );` in your `wp-config.php`.
2. Edit a listing and observe that the Featured Listing sidebar is not available.
3. Check out this branch and refresh the listing editor. Confirm the sidebar is now available (only the environment variable should be required, not the plugins).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
