### PR TITLE
feat(self-serve): enable subscription-only self-serve purchase forms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,10 @@
 				"cat $1 | ./node_modules/.bin/newspack-scripts commitlint"
 			]
 		}
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/src/assets/shared/self-serve-listings.scss
+++ b/src/assets/shared/self-serve-listings.scss
@@ -174,11 +174,18 @@
 		}
 	}
 
-	&.single-only .frequencies {
-		padding-top: 0;
+	&.single-only,
+	&.subscription-only {
+		.frequencies {
+			padding-top: 0;
 
-		.freq-label {
-			display: none;
+			.freq-label {
+				display: none;
+			}
+		}
+
+		.input-container {
+			display: block;
 		}
 	}
 }

--- a/src/blocks/self-serve-listings/block.json
+++ b/src/blocks/self-serve-listings/block.json
@@ -27,9 +27,9 @@
 				}
 			]
 		},
-		"allowSubscription": {
-			"type": "boolean",
-			"default": true
+		"allowedPurchases": {
+			"type": "string",
+			"default": "both"
 		},
 		"buttonText": {
 			"type": "string",

--- a/src/blocks/self-serve-listings/block.json
+++ b/src/blocks/self-serve-listings/block.json
@@ -27,6 +27,10 @@
 				}
 			]
 		},
+		"allowSubscription": {
+			"type": "boolean",
+			"default": true
+		},
 		"allowedPurchases": {
 			"type": "string",
 			"default": "both"

--- a/src/blocks/self-serve-listings/edit.js
+++ b/src/blocks/self-serve-listings/edit.js
@@ -31,6 +31,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 	const [ error, setError ] = useState( null );
 	const {
 		allowedSingleListingTypes,
+		allowSubscription, // Legacy attribute superseded by allowedPurchases.
 		allowedPurchases,
 		buttonText,
 		singleDescription,
@@ -148,7 +149,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 			<div className={ classNames.join( ' ' ) }>
 				<form>
 					<div className="frequencies">
-						{ 'subscription-only' !== allowedPurchases && (
+						{ ( 'subscription-only' !== allowedPurchases || false === allowSubscription ) && (
 							<div className="newspack-listings__form-tabs frequency">
 								<input
 									name="listing-purchase-type"
@@ -156,7 +157,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 									id={ `listing-single-${ clientId }` }
 									type="radio"
 									value="listing-single"
-									checked={ 'single' === selectedType || 'single-only' === allowedPurchases }
+									checked={ 'single' === selectedType || 'single-only' === allowedPurchases || false === allowSubscription }
 									onClick={ () => setSelectedType( 'single' ) }
 								/>
 								<label
@@ -226,7 +227,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 								</div>
 							</div>
 						) }
-						{ 'single-only' !== allowedPurchases && (
+						{ ( 'single-only' !== allowedPurchases && false !== allowSubscription ) && (
 							<div className="newspack-listings__form-tabs frequency">
 								<input
 									name="listing-purchase-type"

--- a/src/blocks/self-serve-listings/edit.js
+++ b/src/blocks/self-serve-listings/edit.js
@@ -12,7 +12,6 @@ import {
 	PanelBody,
 	PanelRow,
 	SelectControl,
-	ToggleControl,
 } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -42,7 +41,14 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 		setAttributes( { clientId } );
 	}, [ clientId ] );
 
+	useEffect( () => {
+		if ( false === allowSubscription ) {
+			setAttributes( { allowedPurchases: 'single-only' } );
+		}
+	}, [ allowSubscription ] );
+
 	const classNames = [ 'newspack-listings__self-serve-form', 'wpbnbd', allowedPurchases ];
+
 	const getPurchaseTypeLabel = () => {
 		switch (allowedPurchases) {
 			case 'both':
@@ -65,7 +71,8 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 								__( 'Allow readers to purchase %s.', 'newspack-listings' ),
 								getPurchaseTypeLabel()
 							) }
-							onChange={ value => setAttributes( { allowedPurchases: value } ) }
+							onChange={ value => setAttributes( { allowedPurchases: value, allowSubscription: true } ) }
+							value={ false === allowSubscription ? 'single-only' : allowedPurchases }
 							options={ [
 								{
 									label: __( 'Single listings and subscriptions', 'newspack-listings' ),

--- a/src/templates/self-serve-form.php
+++ b/src/templates/self-serve-form.php
@@ -14,18 +14,18 @@ call_user_func(
 	function( $data ) {
 		$attributes               = $data['attributes'];
 		$allowed_listing_types    = $attributes['allowedSingleListingTypes'];
-		$allow_subscription       = $attributes['allowSubscription'];
+		$allowed_purchases        = $attributes['allowedPurchases'];
 		$button_text              = $attributes['buttonText'];
 		$single_description       = $attributes['singleDescription'];
 		$subscription_description = $attributes['subscriptionDescription'];
 		$client_id                = $attributes['clientId'];
 		$single_expiration_period = Settings::get_settings( 'newspack_listings_single_purchase_expiration' );
 
-		$class_names = [ 'newspack-listings__self-serve-form', 'wpbnbd' ];
+		$class_names   = [ 'newspack-listings__self-serve-form', 'wpbnbd' ];
+		$class_names[] = $allowed_purchases;
 
-		if ( ! $allow_subscription ) {
-			$class_names[] = 'single-only';
-		}
+		$allow_single       = 'subscription-only' !== $allowed_purchases;
+		$allow_subscription = 'single-only' !== $allowed_purchases;
 
 		if ( empty( $attributes ) ) {
 			return;
@@ -34,106 +34,115 @@ call_user_func(
 <div class="<?php echo esc_attr( implode( ' ', $class_names ) ); ?>">
 	<form>
 		<div class="frequencies">
-			<div class="newspack-listings__form-tabs frequency">
-				<input
-					name="listing-purchase-type"
-					class="newspack-listings__tab-input"
-					id="listing-single-<?php echo esc_attr( $client_id ); ?>"
-					type="radio"
-					checked
-					value="single"
-				/>
-				<label
-					class="freq-label listing-single"
-					for="listing-single-<?php echo esc_attr( $client_id ); ?>"
-				>
-					<?php echo esc_html( __( 'Single Listing' ) ); ?>
-				</label>
-				<div class="input-container listing-details">
-					<p><?php echo wp_kses_post( $single_description ); ?></p>
-					<?php if ( 0 < $single_expiration_period ) : ?>
+			<?php if ( $allow_single ) : ?>
+				<div class="newspack-listings__form-tabs frequency">
+					<?php if ( 'single-only' !== $allowed_purchases ) : ?>
+						<input
+							name="listing-purchase-type"
+							class="newspack-listings__tab-input"
+							id="listing-single-<?php echo esc_attr( $client_id ); ?>"
+							type="radio"
+							checked
+							value="single"
+						/>
+						<label
+							class="freq-label listing-single"
+							for="listing-single-<?php echo esc_attr( $client_id ); ?>"
+						>
+							<?php echo esc_html( __( 'Single Listing' ) ); ?>
+						</label>
+					<?php endif; ?>
+					<div class="input-container listing-details">
+						<p><?php echo wp_kses_post( $single_description ); ?></p>
+						<?php if ( 0 < $single_expiration_period ) : ?>
+							<p class="newspack-listings__help">
+								<?php
+								echo esc_html(
+									sprintf(
+										// Translators: user-facing explanation of expiration behavior.
+										__(
+											'Single-purchase listings expire %d days after the date of publication.',
+											'newspack-listings'
+										),
+										$single_expiration_period
+									)
+								);
+								?>
+							</p>
+						<?php endif; ?>
+						<hr />
+						<h3><?php echo esc_html( __( 'Listing Details', 'newspack-listings' ) ); ?></h3>
+						<label for="listing-title-single-<?php echo esc_attr( $client_id ); ?>">
+							<?php echo esc_html( __( 'Listing Title', 'newspack-listings' ) ); ?>
+						</label>
+						<input
+							type="text"
+							id="listing-title-single-<?php echo esc_attr( $client_id ); ?>"
+							name="listing-title-single"
+							value=""
+							placeholder="<?php echo esc_attr( __( 'My Listing Title' ) ); ?>"
+						/>
+						<label for="listing-type-<?php echo esc_attr( $client_id ); ?>">
+							<?php echo esc_html( __( 'Listing Type', 'newspack-listings' ) ); ?>
+						</label>
+						<select
+							id="listing-type-<?php echo esc_attr( $client_id ); ?>"
+							name="listing-single-type"
+						>
+							<?php
+							array_map(
+								function ( $listing_type ) {
+									?>
+									<option value="<?php echo esc_attr( $listing_type['slug'] ); ?>">
+										<?php echo esc_html( $listing_type['name'] ); ?>
+									</option>
+									<?php
+								},
+								$allowed_listing_types
+							);
+				?>
+						</select>
+						<input
+							type="checkbox"
+							id="listing-single-upgrade-<?php echo esc_attr( $client_id ); ?>"
+							name="listing-featured-upgrade"
+						/>
+						<label for="listing-single-upgrade-<?php echo esc_attr( $client_id ); ?>">
+							<?php echo esc_html( __( 'Upgrade to a featured listing', 'newspack-listings' ) ); ?>
+						</label>
 						<p class="newspack-listings__help">
 							<?php
 							echo esc_html(
-								sprintf(
-									// Translators: user-facing explanation of expiration behavior.
-									__(
-										'Single-purchase listings expire %d days after the date of publication.',
-										'newspack-listings'
-									),
-									$single_expiration_period
+								__(
+									'Featured listings appear first in lists, directory pages and search results.',
+									'newspack-listings'
 								)
 							);
 							?>
 						</p>
-					<?php endif; ?>
-					<hr />
-					<h3><?php echo esc_html( __( 'Listing Details', 'newspack-listings' ) ); ?></h3>
-					<label for="listing-title-single-<?php echo esc_attr( $client_id ); ?>">
-						<?php echo esc_html( __( 'Listing Title', 'newspack-listings' ) ); ?>
-					</label>
-					<input
-						type="text"
-						id="listing-title-single-<?php echo esc_attr( $client_id ); ?>"
-						name="listing-title-single"
-						value=""
-						placeholder="<?php echo esc_attr( __( 'My Listing Title' ) ); ?>"
-					/>
-					<label for="listing-type-<?php echo esc_attr( $client_id ); ?>">
-						<?php echo esc_html( __( 'Listing Type', 'newspack-listings' ) ); ?>
-					</label>
-					<select
-						id="listing-type-<?php echo esc_attr( $client_id ); ?>"
-						name="listing-single-type"
-					>
-						<?php
-						array_map(
-							function ( $listing_type ) {
-								?>
-								<option value="<?php echo esc_attr( $listing_type['slug'] ); ?>">
-									<?php echo esc_html( $listing_type['name'] ); ?>
-								</option>
-								<?php
-							},
-							$allowed_listing_types
-						);
-		?>
-					</select>
-					<input
-						type="checkbox"
-						id="listing-single-upgrade-<?php echo esc_attr( $client_id ); ?>"
-						name="listing-featured-upgrade"
-					/>
-					<label for="listing-single-upgrade-<?php echo esc_attr( $client_id ); ?>">
-						<?php echo esc_html( __( 'Upgrade to a featured listing', 'newspack-listings' ) ); ?>
-					</label>
-					<p class="newspack-listings__help">
-						<?php
-						echo esc_html(
-							__(
-								'Featured listings appear first in lists, directory pages and search results.',
-								'newspack-listings'
-							)
-						);
-						?>
-					</p>
+					</div>
 				</div>
-			</div>
+			<?php endif; ?>
 			<?php if ( $allow_subscription ) : ?>
 				<div class="newspack-listings__form-tabs frequency">
-					<input
-						name="listing-purchase-type"
-						class="newspack-listings__tab-input"
-						id="listing-subscription-<?php echo esc_attr( $client_id ); ?>"
-						type="radio"
-						value="subscription"
-					/>
-					<label
-						class="freq-label listing-subscription"
-						for="listing-subscription-<?php echo esc_attr( $client_id ); ?>"
-					>
-						<?php echo esc_html( __( 'Listing Subscription' ) ); ?>
-					</label>
+					<?php if ( 'subscription-only' !== $allowed_purchases ) : ?>
+						<input
+							name="listing-purchase-type"
+							class="newspack-listings__tab-input"
+							id="listing-subscription-<?php echo esc_attr( $client_id ); ?>"
+							type="radio"
+							value="subscription"
+							<?php if ( 'subscription-only' === $allowed_purchases ) : ?>
+								checked
+							<?php endif; ?>
+						/>
+						<label
+							class="freq-label listing-subscription"
+							for="listing-subscription-<?php echo esc_attr( $client_id ); ?>"
+						>
+							<?php echo esc_html( __( 'Listing Subscription' ) ); ?>
+						</label>
+					<?php endif; ?>
 					<div class="input-container listing-details">
 						<p><?php echo wp_kses_post( $subscription_description ); ?></p>
 						<p class="newspack-listings__help">

--- a/src/templates/self-serve-form.php
+++ b/src/templates/self-serve-form.php
@@ -41,22 +41,20 @@ call_user_func(
 		<div class="frequencies">
 			<?php if ( $allow_single ) : ?>
 				<div class="newspack-listings__form-tabs frequency">
-					<?php if ( 'single-only' !== $allowed_purchases || empty( $allow_subscription ) ) : ?>
-						<input
-							name="listing-purchase-type"
-							class="newspack-listings__tab-input"
-							id="listing-single-<?php echo esc_attr( $client_id ); ?>"
-							type="radio"
-							checked
-							value="single"
-						/>
-						<label
-							class="freq-label listing-single"
-							for="listing-single-<?php echo esc_attr( $client_id ); ?>"
-						>
-							<?php echo esc_html( __( 'Single Listing' ) ); ?>
-						</label>
-					<?php endif; ?>
+					<input
+						name="listing-purchase-type"
+						class="newspack-listings__tab-input"
+						id="listing-single-<?php echo esc_attr( $client_id ); ?>"
+						type="radio"
+						checked
+						value="single"
+					/>
+					<label
+						class="freq-label listing-single"
+						for="listing-single-<?php echo esc_attr( $client_id ); ?>"
+					>
+						<?php echo esc_html( __( 'Single Listing' ) ); ?>
+					</label>
 					<div class="input-container listing-details">
 						<p><?php echo wp_kses_post( $single_description ); ?></p>
 						<?php if ( 0 < $single_expiration_period ) : ?>
@@ -130,24 +128,22 @@ call_user_func(
 			<?php endif; ?>
 			<?php if ( $allow_subscription ) : ?>
 				<div class="newspack-listings__form-tabs frequency">
-					<?php if ( 'subscription-only' !== $allowed_purchases ) : ?>
-						<input
-							name="listing-purchase-type"
-							class="newspack-listings__tab-input"
-							id="listing-subscription-<?php echo esc_attr( $client_id ); ?>"
-							type="radio"
-							value="subscription"
-							<?php if ( 'subscription-only' === $allowed_purchases ) : ?>
-								checked
-							<?php endif; ?>
-						/>
-						<label
-							class="freq-label listing-subscription"
-							for="listing-subscription-<?php echo esc_attr( $client_id ); ?>"
-						>
-							<?php echo esc_html( __( 'Listing Subscription' ) ); ?>
-						</label>
-					<?php endif; ?>
+					<input
+						name="listing-purchase-type"
+						class="newspack-listings__tab-input"
+						id="listing-subscription-<?php echo esc_attr( $client_id ); ?>"
+						type="radio"
+						value="subscription"
+						<?php if ( 'subscription-only' === $allowed_purchases ) : ?>
+							checked
+						<?php endif; ?>
+					/>
+					<label
+						class="freq-label listing-subscription"
+						for="listing-subscription-<?php echo esc_attr( $client_id ); ?>"
+					>
+						<?php echo esc_html( __( 'Listing Subscription' ) ); ?>
+					</label>
 					<div class="input-container listing-details">
 						<p><?php echo wp_kses_post( $subscription_description ); ?></p>
 						<p class="newspack-listings__help">

--- a/src/templates/self-serve-form.php
+++ b/src/templates/self-serve-form.php
@@ -25,6 +25,10 @@ call_user_func(
 		$class_names   = [ 'newspack-listings__self-serve-form', 'wpbnbd' ];
 		$class_names[] = $allowed_purchases;
 
+		if ( empty( $allow_subscription ) ) {
+			$class_names[] = 'single-only';
+		}
+
 		$allow_single       = 'subscription-only' !== $allowed_purchases || empty( $allow_subscription );
 		$allow_subscription = 'single-only' !== $allowed_purchases && ! empty( $allow_subscription );
 

--- a/src/templates/self-serve-form.php
+++ b/src/templates/self-serve-form.php
@@ -14,6 +14,7 @@ call_user_func(
 	function( $data ) {
 		$attributes               = $data['attributes'];
 		$allowed_listing_types    = $attributes['allowedSingleListingTypes'];
+		$allow_subscription       = $attributes['allowSubscription']; // Legacy attribute superseded by allowedPurchases.
 		$allowed_purchases        = $attributes['allowedPurchases'];
 		$button_text              = $attributes['buttonText'];
 		$single_description       = $attributes['singleDescription'];
@@ -24,8 +25,8 @@ call_user_func(
 		$class_names   = [ 'newspack-listings__self-serve-form', 'wpbnbd' ];
 		$class_names[] = $allowed_purchases;
 
-		$allow_single       = 'subscription-only' !== $allowed_purchases;
-		$allow_subscription = 'single-only' !== $allowed_purchases;
+		$allow_single       = 'subscription-only' !== $allowed_purchases || empty( $allow_subscription );
+		$allow_subscription = 'single-only' !== $allowed_purchases && ! empty( $allow_subscription );
 
 		if ( empty( $attributes ) ) {
 			return;
@@ -36,7 +37,7 @@ call_user_func(
 		<div class="frequencies">
 			<?php if ( $allow_single ) : ?>
 				<div class="newspack-listings__form-tabs frequency">
-					<?php if ( 'single-only' !== $allowed_purchases ) : ?>
+					<?php if ( 'single-only' !== $allowed_purchases || empty( $allow_subscription ) ) : ?>
 						<input
 							name="listing-purchase-type"
 							class="newspack-listings__tab-input"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The self-serve purchase form currently allows disabling subscription purchases, but not single listing purchases. This PR allows editors to choose whether the self-serve block should allow single listings, subscription listings, or both. It deprecates the legacy `allowSubscription` boolean block attribute by treating it as a `single-only` value for `allowedPurchases`.

Related to #145.

<img width="837" alt="Screen Shot 2022-04-14 at 5 03 33 PM" src="https://user-images.githubusercontent.com/2230142/163492924-c15ed4a8-31e1-454f-a580-8476561e9fdc.png">

### How to test the changes in this Pull Request:

1. On `master`, add a self-serve listings block to a post or page. Turn off the toggle for "Allow subscriptions".
2. Check out this branch and refresh the editor. Confirm that the block display doesn't change in either the editor or on the front-end, and that it's not showing the "Listing Subscription" tab.
3. Select the block in the editor and confirm that the "Allow subscriptions" toggle is replaced by a dropdown with three options:

<img width="275" alt="Screen Shot 2022-04-14 at 5 29 27 PM" src="https://user-images.githubusercontent.com/2230142/163493065-2f55ea94-3e25-448a-bf92-f9480679a430.png">

4. Test each option and confirm that the block display changes accordingly in both the editor and on the front-end and that submitting the form continues to result in the expected products on checkout (subscription products from a subscription-only form, and single listing products from a single-only form).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
