### PR TITLE
fix(featured): set or unset featured status on manual post save

### DIFF
--- a/includes/class-featured.php
+++ b/includes/class-featured.php
@@ -33,7 +33,7 @@ final class Featured {
 	/**
 	 * Installed version number of the custom table.
 	 */
-	const TABLE_VERSION = '1.0';
+	const TABLE_VERSION = '1.1';
 
 	/**
 	 * Option name for the installed version number of the custom table.
@@ -69,7 +69,7 @@ final class Featured {
 		}
 
 		register_activation_hook( NEWSPACK_LISTINGS_FILE, [ __CLASS__, 'create_custom_table' ] );
-		add_action( 'plugins_loaded', [ __CLASS__, 'check_update_version' ] );
+		add_action( 'admin_init', [ __CLASS__, 'check_update_version' ] );
 		add_action( 'init', [ __CLASS__, 'register_featured_meta' ] );
 		add_action( 'init', [ __CLASS__, 'cron_init' ] );
 		add_action( 'save_post', [ __CLASS__, 'update_featured_status_on_save' ], 10, 2 );

--- a/includes/class-featured.php
+++ b/includes/class-featured.php
@@ -408,7 +408,7 @@ final class Featured {
 	 * @param WP_Post $post WP_Post object being saved.
 	 */
 	public static function update_featured_status_on_save( $post_id, $post ) {
-		if ( ! Core::is_listing( $post->post_type ) ) {
+		if ( ! Core::is_listing( $post->post_type ) || ! self::is_active() ) {
 			return;
 		}
 

--- a/includes/class-featured.php
+++ b/includes/class-featured.php
@@ -69,7 +69,7 @@ final class Featured {
 		}
 
 		register_activation_hook( NEWSPACK_LISTINGS_FILE, [ __CLASS__, 'create_custom_table' ] );
-		add_action( 'admin_init', [ __CLASS__, 'check_update_version' ] );
+		add_action( 'init', [ __CLASS__, 'check_update_version' ] );
 		add_action( 'init', [ __CLASS__, 'register_featured_meta' ] );
 		add_action( 'init', [ __CLASS__, 'cron_init' ] );
 		add_action( 'save_post', [ __CLASS__, 'update_featured_status_on_save' ], 10, 2 );

--- a/includes/class-featured.php
+++ b/includes/class-featured.php
@@ -72,6 +72,7 @@ final class Featured {
 		add_action( 'plugins_loaded', [ __CLASS__, 'check_update_version' ] );
 		add_action( 'init', [ __CLASS__, 'register_featured_meta' ] );
 		add_action( 'init', [ __CLASS__, 'cron_init' ] );
+		add_action( 'save_post', [ __CLASS__, 'update_featured_status_on_save' ], 10, 2 );
 		add_action( self::CRON_HOOK, [ __CLASS__, 'check_expired_featured_items' ] );
 		add_filter( 'posts_clauses', [ __CLASS__, 'sort_featured_listings' ], 10, 2 );
 		add_filter( 'post_class', [ __CLASS__, 'add_featured_classes' ] );
@@ -399,6 +400,33 @@ final class Featured {
 	}
 
 	/**
+	 * Feature priority is updated on the fly via the block editor.
+	 * However, if you never touch the default priority control, it won't be updated in the custom table.
+	 * This ensures that the feature priority is set on save if the post is featured but has no priority.
+	 *
+	 * @param int     $post_id Post ID being saved.
+	 * @param WP_Post $post WP_Post object being saved.
+	 */
+	public static function update_featured_status_on_save( $post_id, $post ) {
+		if ( ! Core::is_listing( $post->post_type ) ) {
+			return;
+		}
+
+		$is_featured      = get_post_meta( $post_id, self::META_KEYS['featured'], true );
+		$feature_priority = self::get_priority( $post_id );
+
+		// If the post is set to be featured but has no priority, set the default.
+		if ( $is_featured && 0 === $feature_priority ) {
+			self::update_priority( $post_id, 5 );
+		}
+
+		// If the post is set to not be featured, delete any priority values.
+		if ( ! $is_featured ) {
+			self::update_priority( $post_id, 0 );
+		}
+	}
+
+	/**
 	 * Set featured status, priority, and expiration date for the given post.
 	 *
 	 * @param int    $post_id Post ID to update.
@@ -411,7 +439,6 @@ final class Featured {
 		if ( null === $post_id ) {
 			return false;
 		}
-
 		// Set featured status.
 		update_post_meta( $post_id, self::META_KEYS['featured'], true );
 

--- a/tests/test-featured.php
+++ b/tests/test-featured.php
@@ -6,7 +6,7 @@
  */
 
 use \Newspack_Listings\Core;
-use \Newspack_Listings\Featured as Featured;
+use \Newspack_Listings\Featured;
 use \Newspack_Listings\Utils;
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently, feature priority is set in a custom DB table that's used to sort featured listings first. This table is updated when a featured listing is generated automatically (such as via self-serve purchase), as well as when the priority value is changed in the WP block editor. The priority value is automatically deleted (and the featured status toggled off) via cron job if the listing's featured expiration date passes.

However, the priority value is currently NOT updated if you simply manually toggle on the Featured status for a listing in the block editor without altering the default priority value of 5. This PR fixes that, and also ensures that the priority data is deleted on save after manually toggling OFF the featured status in the block editor.

This PR also bumps the value of the `newspack_listings_priority_version` option so that any posts that were affected by this oversight should get automatically updated with the correct priority value in the custom DB table. It also moves this version check from `plugins_loaded` to `init`, as `\WP_Query` was throwing fatals when used on `plugins_loaded`.

### How to test the changes in this Pull Request:

1. On `master`, create and publish a listing of any type. Under "Featured Listing Settings" toggle ON the "Featured listing" option without touching the "Priority level" slider, and save the post.
2. Inspect your WP tables using raw queries, Adminer, or Sequel Pro. In the `wp_newspack_listings_priority` table, observe that a new row is not created for the post you just updated.
3. Check out this branch and refresh the WP admin dashboard. Confirm that the `wp_newspack_listings_priority` table is updated with a row for the post you just updated is automatically populated with the default value of `5` (due to this PR bumping the `newspack_listings_priority_version` option).
4. Create or edit another listing and repeat step 1.
5. This time confirm that a new row is created in the `wp_newspack_listings_priority` table for the saved post with the default value `5`.
6. Toggle OFF the "featured listing" option for the post and confirm that its row in the `wp_newspack_listings_priority` table is deleted on save.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
