### PR TITLE
feat: enable jetpack share buttons on listings

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -82,6 +82,8 @@ final class Core {
 		add_filter( 'newspack_sponsors_post_types', [ __CLASS__, 'support_newspack_sponsors' ] );
 		add_filter( 'jetpack_relatedposts_filter_options', [ __CLASS__, 'disable_jetpack_related_posts' ] );
 		add_filter( 'jetpack_related_posts_customize_options', [ __CLASS__, 'disable_jetpack_related_posts_customizer' ] );
+		add_filter( 'sharing_enqueue_scripts', [ __CLASS__, 'enable_jetpack_social_share_buttons' ] );
+		add_filter( 'sharing_show', [ __CLASS__, 'enable_jetpack_social_share_buttons' ] );
 		add_filter( 'wpseo_primary_term_taxonomies', [ __CLASS__, 'disable_yoast_primary_categories' ], 10, 2 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'enable_listing_category_archives' ], 11 );
 		register_activation_hook( NEWSPACK_LISTINGS_FILE, [ __CLASS__, 'activation_hook' ] );
@@ -807,6 +809,21 @@ final class Core {
 		}
 
 		return $options;
+	}
+
+	/**
+	 * If social share buttons are enabled in Jetpack, allow them to appear on listings.
+	 *
+	 * @param bool $show True if the sharing buttons should be displayed.
+	 *
+	 * @return bool The filtered value.
+	 */
+	public static function enable_jetpack_social_share_buttons( $show ) {
+		if ( is_singular( array_values( self::NEWSPACK_LISTINGS_POST_TYPES ) ) ) {
+			return true;
+		}
+
+		return $show;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If sharing buttons are enabled in Jetpack, allow them to appear on listings as well as posts/pages.

Closes #255.

### How to test the changes in this Pull Request:

1. Under **Jetpack > Settings > Sharing**,  enable sharing buttons:

<img width="1043" alt="Screen Shot 2022-05-12 at 4 20 44 PM" src="https://user-images.githubusercontent.com/2230142/168177075-5d5fb3e7-5891-4315-99c0-2a66dd427c54.png">

2. On `master`, publish a listing and view it on the front-end. Observe that no share buttons are displayed.
3. Check out this branch, refresh, and confirm that the share buttons are displayed and work exactly as they do for posts and pages.
4. Check the listing in both AMP and non-AMP modes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
