### PR TITLE
fix: restore Related Content settings section, but only if Jetpack Related Posts is on

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -50,6 +50,14 @@ final class Settings {
 			];
 		}
 
+		// If Related Posts is on, add a section for it.
+		if ( class_exists( 'Jetpack_RelatedPosts' ) ) {
+			$sections['related'] = [
+				'slug'  => 'newspack_listings_related_settings',
+				'title' => __( 'Related Content Settings', 'newspack-listings' ),
+			];
+		}
+
 		return $sections;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#256 deprecated and removed all features and settings for Related Listings. However, there's a somewhat-hidden feature in the plugin which uses one of the settings page sections for related content, so we need to restore that section when Jetpack's Related Posts module is turned on.

### How to test the changes in this Pull Request:

1. On `master`, turn on Jetpack's Related Posts module (**Jetpack > Settings > Traffic**).
2. Go to **Listings > Settings** and observe a PHP warning in debug.log:

```
Notice: Undefined index: related in /srv/htdocs/wp-content/plugins/newspack-listings/includes/class-settings.php on line 163
Notice: Trying to access array offset on value of type null in /srv/htdocs/wp-content/plugins/newspack-listings/includes/class-settings.php on line 163
```

3. Check out this branch, refresh the Newspack Listings settings page, and confirm that the warning is no longer thrown and that the setting is displayed properly:

<img width="682" alt="Screen Shot 2022-05-30 at 11 06 51 AM" src="https://user-images.githubusercontent.com/2230142/171036187-54831594-04cc-4d63-81ad-591cfbb3a1b9.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
