### PR TITLE
fix: allow featured listings features to be enabled independently of self-serve

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  newspack: adekbadek/newspack@1.1.1
+  newspack: adekbadek/newspack@1.3.0
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.11.1-hotfix.1](https://github.com/Automattic/newspack-listings/compare/v2.11.0...v2.11.1-hotfix.1) (2022-06-14)
+
+
+### Bug Fixes
+
+* allow featured listings features to be enabled independently of self-serve ([868c6ff](https://github.com/Automattic/newspack-listings/commit/868c6ffa166ec4ab84baa3a03a1101731772076b))
+
 # [2.11.0](https://github.com/Automattic/newspack-listings/compare/v2.10.0...v2.11.0) (2022-05-30)
 
 

--- a/includes/class-featured.php
+++ b/includes/class-featured.php
@@ -82,10 +82,10 @@ final class Featured {
 	/**
 	 * Check whether featured listings should be active on this site.
 	 * Requires either the `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` or
-	 * `NEWSPACK_LSITINGS_FEATURED_LISTINGS_ENABLED` environment constants.
+	 * `NEWSPACK_LISTINGS_FEATURED_ENABLED` environment constants.
 	 */
 	public static function is_active() {
-		return ( defined( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED' ) && NEWSPACK_LISTINGS_SELF_SERVE_ENABLED ) || ( defined( 'NEWSPACK_LSITINGS_FEATURED_LISTINGS_ENABLED' ) && NEWSPACK_LSITINGS_FEATURED_LISTINGS_ENABLED );
+		return ( defined( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED' ) && NEWSPACK_LISTINGS_SELF_SERVE_ENABLED ) || ( defined( 'NEWSPACK_LISTINGS_FEATURED_ENABLED' ) && NEWSPACK_LISTINGS_FEATURED_ENABLED );
 	}
 
 	/**

--- a/includes/class-featured.php
+++ b/includes/class-featured.php
@@ -81,10 +81,11 @@ final class Featured {
 
 	/**
 	 * Check whether featured listings should be active on this site.
-	 * Requires the `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` environment constant.
+	 * Requires either the `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` or
+	 * `NEWSPACK_LSITINGS_FEATURED_LISTINGS_ENABLED` environment constants.
 	 */
 	public static function is_active() {
-		return defined( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED' ) && NEWSPACK_LISTINGS_SELF_SERVE_ENABLED;
+		return ( defined( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED' ) && NEWSPACK_LISTINGS_SELF_SERVE_ENABLED ) || ( defined( 'NEWSPACK_LSITINGS_FEATURED_LISTINGS_ENABLED' ) && NEWSPACK_LSITINGS_FEATURED_LISTINGS_ENABLED );
 	}
 
 	/**

--- a/newspack-listings.php
+++ b/newspack-listings.php
@@ -7,7 +7,7 @@
  * Author URI:      https://newspack.pub
  * Text Domain:     newspack-listings
  * Domain Path:     /languages
- * Version:         2.11.0
+ * Version:         2.11.1-hotfix.1
  *
  * @package         Newspack_Listings
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-listings",
-  "version": "2.11.0",
+  "version": "2.11.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-listings",
-      "version": "2.11.0",
+      "version": "2.11.1-hotfix.1",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "newspack-components": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-listings",
-  "version": "2.11.0",
+  "version": "2.11.1-hotfix.1",
   "description": "",
   "scripts": {
     "cm": "newspack-scripts commit",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Up til now, all Newspack clients who use featured listings either use or are experimenting with self-serve features, so the two feature sets were gated behind a single `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` environment constant. 

This fix allows featured listings to be enabled without also enabling self-serve listings. The two featuresets work independently, but self-serve listings require featured listings to be enabled, so the `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` constant alone will still enable both featuresets. But now, a `NEWSPACK_LISTINGS_FEATURED_ENABLED` constant will enable only featured listings and not self-serve listings.

### How to test the changes in this Pull Request:

1. Check out this branch and ensure your `wp-config.php` file does not have either the `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` or `NEWSPACK_LISTINGS_FEATURED_ENABLED` constants defined.
2. Go to **Listings > Settings** and confirm that you don't see the settings for self-serve listings, and that you can't add a self-serve form block to any page or post.
3. Edit a listing of any type and confirm that no Featured Listing sidebar panel is loaded in the editor.
4. Add `define( 'NEWSPACK_LISTINGS_FEATURED_ENABLED', true );` to your `wp-config.php` file.
5. Edit a listing and confirm that you do see the Featured Listing sidebar panel now. Enable it for a few listings sharing a category, set some varying priorities, and view the category archive. Confirm that the featured listings appear at the top of the archive in priority order.
6. Repeat step 2 and confirm that you still can't see or use any self-serve listing features.
7. Add `define( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED', true );` to your `wp-config.php` and remove the `NEWSPACK_LISTINGS_FEATURED_ENABLED` constant, or set it to `false`.
8. Repeat step 2 and confirm that you can now see and edit self-serve options, and add a self-serve form block to a post/page.
9. Repeat step 5 and confirm that you can still see/edit featured listing settings, and that these settings still affect query order.
10. Enable both constants and repeat steps 8-9.
11. Disable both constants and confirm that all self-serve and featured listing features are no longer available, and that the query order falls back to the WP default (descending order of publish date).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
