### PR TITLE
fix: prevent dupes of self-serve products; manual creation and deletion

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -91,7 +91,7 @@ final class Blocks {
 			'time_format'        => get_option( 'time_format' ),
 
 			// Self-serve listings features are gated behind an environment variable.
-			'self_serve_enabled' => Products::is_active(),
+			'self_serve_enabled' => Products::is_active() && Products::validate_products(),
 			'featured_enabled'   => Featured::is_active(),
 		];
 

--- a/includes/class-products.php
+++ b/includes/class-products.php
@@ -91,7 +91,7 @@ class Products {
 	public static function init() {
 		// WP actions to create the necessary products, and to handle submission of the Self-Serve Listings block form.
 		add_action( 'init', [ __CLASS__, 'setup' ] );
-		add_action( 'wp_loaded', [ __CLASS__, 'perform_action' ], 99 );
+		add_action( 'wp_loaded', [ __CLASS__, 'create_or_delete_listing_products' ], 99 );
 
 		// When product settings are updated, make sure to update the corresponding WooCommerce products as well.
 		add_action( 'update_option', [ __CLASS__, 'update_products' ], 10, 3 );
@@ -146,19 +146,14 @@ class Products {
 	/**
 	 * Create or delete self-serve listing products.
 	 */
-	public static function perform_action() {
+	public static function create_or_delete_listing_products() {
 		$action = filter_input( INPUT_GET, 'newspack-listings-products', FILTER_SANITIZE_STRING );
 		$nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
 
 		if ( wp_verify_nonce( $nonce, self::ACTION_NONCE ) && in_array( $action, self::ACTIONS, true ) ) {
-			$create = self::ACTIONS['create'] === $action;
-			$delete = self::ACTIONS['delete'] === $action;
-
-			if ( $create ) {
+			if ( self::ACTIONS['create'] === $action ) {
 				self::create_products();
-			}
-
-			if ( $delete ) {
+			} elseif ( self::ACTIONS['delete'] === $action ) {
 				self::delete_products();
 			}
 

--- a/includes/class-products.php
+++ b/includes/class-products.php
@@ -90,7 +90,7 @@ class Products {
 	 */
 	public static function init() {
 		// WP actions to create the necessary products, and to handle submission of the Self-Serve Listings block form.
-		add_action( 'init', [ __CLASS__, 'setup' ] );
+		add_action( 'woocommerce_after_register_post_type', [ __CLASS__, 'setup' ] );
 		add_action( 'wp_loaded', [ __CLASS__, 'create_or_delete_listing_products' ], 99 );
 
 		// When product settings are updated, make sure to update the corresponding WooCommerce products as well.

--- a/includes/class-products.php
+++ b/includes/class-products.php
@@ -171,6 +171,9 @@ class Products {
 	 * Create the WooCommerce products for self-serve listings.
 	 */
 	public static function create_products() {
+		// First, clean up any potential leftover dupes.
+		self::delete_products();
+
 		$settings     = Settings::get_settings();
 		$product_name = __( 'Self-Serve Listings', 'newspack-listings' );
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -83,10 +83,11 @@ final class Settings {
 		echo wp_kses_post(
 			sprintf(
 				// Translators: instructions on how to fix missing self-serve products.
-				__( 'Self-serve listing features are %1$s. <a href="%2$s">Click here to %3$s self-serve listings features on this site</a>.', 'newspack-listings' ),
+				__( 'Self-serve listing features are %1$s. <a href="%2$s">Click here to %3$s self-serve listings features on this site</a>.%4$s', 'newspack-listings' ),
 				$is_valid ? __( 'active', 'newspack-listings' ) : __( 'not active', 'newspack-listings' ),
 				$redirect,
-				$is_valid ? __( 'disable', 'newspack-listings' ) : __( 'enable', 'newspack-listings' )
+				$is_valid ? __( 'disable', 'newspack-listings' ) : __( 'enable', 'newspack-listings' ),
+				$is_valid ? __( ' <b>Warning:</b> Disabling will cancel all existing self-serve listing subscriptions.', 'newspack-listings' ) : ''
 			)
 		);
 	}

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -17,6 +17,11 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Settings {
 	/**
+	 * Slug to use for settings page.
+	 */
+	const PAGE_SLUG = 'newspack-listings-settings-admin';
+
+	/**
 	 * Set up hooks.
 	 */
 	public static function init() {
@@ -45,8 +50,9 @@ final class Settings {
 		// Product settings are only relevant if WooCommerce is available.
 		if ( Products::is_active() ) {
 			$sections['product'] = [
-				'slug'  => 'newspack_listings_product_settings',
-				'title' => __( 'Self-Serve Settings', 'newspack-listings' ),
+				'slug'        => 'newspack_listings_product_settings',
+				'title'       => __( 'Self-Serve Settings', 'newspack-listings' ),
+				'description' => [ __CLASS__, 'get_self_serve_section_description' ],
 			];
 		}
 
@@ -59,6 +65,30 @@ final class Settings {
 		}
 
 		return $sections;
+	}
+
+	/**
+	 * Output a description for the self-serve listings section.
+	 */
+	public static function get_self_serve_section_description() {
+		$products = Products::get_products();
+		$is_valid = false !== $products && ! is_wp_error( $products );
+		$redirect = wp_nonce_url(
+			add_query_arg(
+				[ 'newspack-listings-products' => $is_valid ? Products::ACTIONS['delete'] : Products::ACTIONS['create'] ],
+				menu_page_url( self::PAGE_SLUG, false )
+			),
+			Products::ACTION_NONCE
+		);
+		echo wp_kses_post(
+			sprintf(
+				// Translators: instructions on how to fix missing self-serve products.
+				__( 'Self-serve listing features are %1$s. <a href="%2$s">Click here to %3$s self-serve listings features on this site</a>.', 'newspack-listings' ),
+				$is_valid ? __( 'active', 'newspack-listings' ) : __( 'not active', 'newspack-listings' ),
+				$redirect,
+				$is_valid ? __( 'disable', 'newspack-listings' ) : __( 'enable', 'newspack-listings' )
+			)
+		);
 	}
 
 	/**
@@ -174,7 +204,8 @@ final class Settings {
 
 		// Product settings are only relevant if WooCommerce is available.
 		if ( Products::is_active() ) {
-			$product_settings = [
+			$products_are_invalid = ! Products::validate_products();
+			$product_settings     = [
 				[
 					'description' => __( 'The base price for a single listing (no subscription).', 'newspack-listings' ),
 					'key'         => Products::PRODUCT_META_KEYS['single'],
@@ -182,6 +213,7 @@ final class Settings {
 					'type'        => 'number',
 					'value'       => 25,
 					'section'     => $sections['product']['slug'],
+					'disabled'    => $products_are_invalid,
 				],
 				[
 					'description' => __( 'The upgrade price to make a single-purchase listing "featured."', 'newspack-listings' ),
@@ -190,6 +222,7 @@ final class Settings {
 					'type'        => 'number',
 					'value'       => 75,
 					'section'     => $sections['product']['slug'],
+					'disabled'    => $products_are_invalid,
 				],
 				// TODO: update all copy to be able to handle just 1 day in addition to multiple.
 				[
@@ -199,6 +232,7 @@ final class Settings {
 					'type'        => 'number',
 					'value'       => 30,
 					'section'     => $sections['product']['slug'],
+					'disabled'    => $products_are_invalid,
 				],
 				[
 					'description' => __( 'The base monthly subscription price. This fee is charged monthly.', 'newspack-listings' ),
@@ -207,6 +241,7 @@ final class Settings {
 					'type'        => 'number',
 					'value'       => 50,
 					'section'     => $sections['product']['slug'],
+					'disabled'    => $products_are_invalid,
 				],
 				[
 					'description' => __( 'The upgrade price for a premium subscription, which allows subscribers to create up to 10 additional Marketplace or Event listings. This fee is charged monthly.', 'newspack-listings' ),
@@ -215,6 +250,7 @@ final class Settings {
 					'type'        => 'number',
 					'value'       => 100,
 					'section'     => $sections['product']['slug'],
+					'disabled'    => $products_are_invalid,
 				],
 			];
 
@@ -277,14 +313,14 @@ final class Settings {
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Newspack Listings: Site-Wide Settings', 'newspack-listings' ); ?></h1>
 			<form method="post" action="options.php">
-			<?php
-				settings_fields( 'newspack_listings_options_group' );
-				do_settings_sections( 'newspack-listings-settings-admin' );
-				submit_button();
-			?>
+					<?php
+					settings_fields( 'newspack_listings_options_group' );
+					do_settings_sections( self::PAGE_SLUG );
+					submit_button();
+					?>
 			</form>
 		</div>
-		<?php
+					<?php
 	}
 
 	/**
@@ -294,7 +330,8 @@ final class Settings {
 		$sections = self::get_sections();
 
 		foreach ( $sections as $section ) {
-			add_settings_section( $section['slug'], $section['title'], null, 'newspack-listings-settings-admin' );
+			$section_description = isset( $section['description'] ) ? $section['description'] : null;
+			add_settings_section( $section['slug'], $section['title'], $section_description, self::PAGE_SLUG );
 		}
 
 		foreach ( self::get_default_settings() as $setting ) {
@@ -306,7 +343,7 @@ final class Settings {
 				$setting['key'],
 				$setting['label'],
 				[ __CLASS__, 'newspack_listings_settings_callback' ],
-				'newspack-listings-settings-admin',
+				self::PAGE_SLUG,
 				$setting['section'],
 				$setting
 			);
@@ -325,16 +362,18 @@ final class Settings {
 	 * @param array $setting Settings array.
 	 */
 	public static function newspack_listings_settings_callback( $setting ) {
-		$key   = $setting['key'];
-		$type  = $setting['type'];
-		$value = get_option( $key, $setting['value'] );
+		$key      = $setting['key'];
+		$type     = $setting['type'];
+		$disabled = isset( $setting['disabled'] ) && $setting['disabled'];
+		$value    = get_option( $key, $setting['value'] );
 
 		if ( 'checkbox' === $type ) {
 			printf(
-				'<input type="checkbox" id="%s" name="%s" %s /><p class="description" for="%s">%s</p>',
+				'<input type="checkbox" id="%s" name="%s" %s %s /><p class="description" for="%s">%s</p>',
 				esc_attr( $key ),
 				esc_attr( $key ),
 				! empty( $value ) ? 'checked' : '',
+				$disabled ? 'disabled' : '', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				esc_attr( $key ),
 				wp_kses_post( $setting['description'] )
 			);
@@ -343,10 +382,11 @@ final class Settings {
 				$value = $setting['value'];
 			}
 			printf(
-				'<input type="number" id="%s" name="%s" value="%s" class="small-text" /><p class="description" for="%s">%s</p>',
+				'<input type="number" id="%s" name="%s" value="%s" class="small-text" %s /><p class="description" for="%s">%s</p>',
 				esc_attr( $key ),
 				esc_attr( $key ),
 				esc_attr( $value ),
+				$disabled ? 'disabled' : '',
 				esc_attr( $key ),
 				wp_kses_post( $setting['description'] )
 			);
@@ -355,10 +395,11 @@ final class Settings {
 				$value = $setting['value'];
 			}
 			printf(
-				'<input type="text" id="%s" name="%s" value="%s" class="regular-text" /><p class="description" for="%s">%s</p>',
+				'<input type="text" id="%s" name="%s" value="%s" class="regular-text" %s /><p class="description" for="%s">%s</p>',
 				esc_attr( $key ),
 				esc_attr( $key ),
 				esc_attr( $value ),
+				$disabled ? 'disabled' : '',
 				esc_attr( $key ),
 				wp_kses_post( $setting['description'] )
 			);

--- a/src/blocks/self-serve-listings/view.php
+++ b/src/blocks/self-serve-listings/view.php
@@ -39,7 +39,7 @@ function register_block() {
  */
 function render_block( $attributes ) {
 	// Only render if self-serve listings features are active.
-	if ( ! Products::is_active() ) {
+	if ( ! Products::is_active() || ! Products::validate_products() ) {
 		return '';
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When self-serve listings are enabled, the plugin automatically generates the required WooCommerce products it needs to enable the reader-facing purchase flow. However, if any of these products is unpublished or deleted, the plugin will regenerate them, potentially resulting in many unwanted duplicates.

This PR removes the auto-generation and instead requires an intentional action on the part of site admins to create the products before self-serve features can be used. It also allows for deletion of the products (thus disabling self-serve purchase features) if self-serve isn't needed on the site.

The UI is fairly bare-bones as self-serve features are still experimental, but this does prevent a situation where unwanted products can be created en masse.

### How to test the changes in this Pull Request:

1. On a new site, install this plugin, WooCommerce, and WooCommerce Subscriptions. Add the `define( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED', true );` flag to `wp-config.php` to enable self-serve features.
2. Go to **Listings > Settings** and observe that the "Self-Serve Listings" section is available, but its fields are disabled.

<img width="667" alt="Screen Shot 2022-07-12 at 11 17 19 AM" src="https://user-images.githubusercontent.com/2230142/178553316-fad3b570-9d9c-4782-ac2f-8fddc6e9940a.png">

3. Edit a post or page and attempt to insert a Self-Serve purchase form block, and confirm that you can't.
4. Go to Products and confirm that no self-serve listings products exist yet, as you haven't created them.
5. Go back to Listings > Settings and click the "Click here to enable self-serve listings features on this site" link.
6. Confirm that the self-serve settings are now editable.
7. Go to Products and confirm that the self-serve products were generated.
8. Edit a post or page and confirm that you can insert a Self-Serve purchase form block, and that it functions as expected on the front-end.
9. Go back to Listings > Settings and click on the "Click here to disable self-serve listings features on this site" link.
10. Confirm that the self-serve settings are disabled again, the products have been deleted, and that the Self-Serve purchase form block is no longer available in the editor or on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
