### PR TITLE
feat: filter disabled WC my-account pages

### DIFF
--- a/includes/class-products.php
+++ b/includes/class-products.php
@@ -106,6 +106,9 @@ class Products {
 			new Products_Ui();
 			new Products_User();
 			new Products_Cron();
+
+			// Filter the WC "My Account" pages disabled by the Newspack plugin.
+			add_filter( 'newspack_my_account_disabled_pages', [ __CLASS__, 'my_account_disabled_pages' ] );
 		}
 	}
 
@@ -402,6 +405,20 @@ class Products {
 		}
 
 		return (int) $post->post_author === (int) $user_id;
+	}
+
+	/**
+	 * Filter "My Account" disabled pages.
+	 *
+	 * @param string[] $pages Array of page slugs.
+	 */
+	public static function my_account_disabled_pages( $pages ) {
+		foreach ( $pages as $key => $slug ) {
+			if ( in_array( $slug, [ 'orders', 'subscriptions' ] ) ) {
+				unset( $pages[ $key ] );
+			}
+		}
+		return $pages;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-plugin/pull/1761 introduces filtering of WC "My Account" pages. This PR ensures that the pages needed for self-serve listing are added if needed.

To be merged after https://github.com/Automattic/newspack-plugin/pull/1761

### How to test the changes in this Pull Request:

1. Enable self-serve Listings
2. Switch the Newspack plugin to https://github.com/Automattic/newspack-plugin/pull/1761
3. Observe "My Account" has Orders and Subscriptions pages

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->