### PR TITLE
Curated List: make sure custom CSS classes are output

### DIFF
--- a/src/blocks/curated-list/block.json
+++ b/src/blocks/curated-list/block.json
@@ -2,6 +2,10 @@
 	"name": "newspack-listings/curated-list",
 	"category": "newspack",
 	"attributes": {
+		"className": {
+			"type": "string",
+			"default": ""
+		},
 		"isSelected": {
 			"type": "boolean",
 			"default": false

--- a/src/blocks/curated-list/view.php
+++ b/src/blocks/curated-list/view.php
@@ -45,7 +45,7 @@ function render_block( $attributes, $inner_content ) {
 	$is_amp = Utils\is_amp();
 
 	// Conditional class names based on attributes.
-	$classes = [ 'newspack-listings__curated-list' ];
+	$classes = [ 'newspack-listings__curated-list', esc_attr( $attributes['className'] ) ];
 
 	if ( $attributes['showNumbers'] ) {
 		$classes[] = 'show-numbers';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the Curated List block applies custom CSS classes to the front-end.

Closes #278.

### How to test the changes in this Pull Request:

1. Add a Curated List block in the editor, and give it a custom CSS class under the Advanced panel in the right sidebar.
2. Publish the page.
3. Inspect the Curated List block on the front-end; note that your CSS class is not being output (it should be on the outer most element of the block, with the CSS class `newspack-listings__curated-list`. 
4. Apply the PR.
5. Refresh the page; confirm that the block now shows up.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
