### PR TITLE
fix: remove content check before loading Curated List styles

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -208,14 +208,12 @@ final class Blocks {
 		}
 
 		// Styles for Curated List block.
-		if ( is_singular() && has_block( 'newspack-listings/curated-list', $post_id ) ) {
-			wp_enqueue_style(
-				'newspack-listings-curated-list',
-				NEWSPACK_LISTINGS_URL . 'dist/curated-list.css',
-				[],
-				NEWSPACK_LISTINGS_VERSION
-			);
-		}
+		wp_enqueue_style(
+			'newspack-listings-curated-list',
+			NEWSPACK_LISTINGS_URL . 'dist/curated-list.css',
+			[],
+			NEWSPACK_LISTINGS_VERSION
+		);
 
 		// Styles for any singular listing type.
 		if ( is_singular( array_values( Core::NEWSPACK_LISTINGS_POST_TYPES ) ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes the check before loading the Curated List block styles. 

Originally the plugin checked if the block existed in the page content before loading the styles. This meant the styles weren't loading if the block was only inserted into a widget space on the page, or in a reusable block.

We should be able to fix the widget issue with a similar check, but the reusable block bit is trickier -- the blocks inside of a reusable block don't exist in a page's content the same way as adding a regular block directly to the editor.

Though this means loading more CSS, I think this is the best fix for now; it could be worth trying to solve the reusable block question, though, and if it is possible to do, it could be worth moving to our block plugin, too. 

(@dkoo if you'd rather try to resolve the reusable blocks question instead, please let me know! I might be jumping the gun here). 

Closes #291

### How to test the changes in this Pull Request:

1. Create a reusable block with a Curated Listing block inside of it; change the font size and image alignment. Add the reusable block to a post or page and publish.
2. View the page and note the curated-list.css style is not loading (your font size won't be applied, and the image alignment won't work). 
3. Add a Curated List block to the sidebar widget area and edit the settings; view on the front end and note the same issue.
4. Apply this PR.
5. Re-test both cases and confirm the styles are now loading for the block. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
