### PR TITLE
refactor: remove use of __experimentalMainDashboardButton

### DIFF
--- a/includes/products/class-products-user.php
+++ b/includes/products/class-products-user.php
@@ -25,6 +25,7 @@ final class Products_User extends Products {
 		add_filter( 'allowed_block_types_all', [ $this, 'restrict_blocks_for_customers' ], 10, 2 );
 		add_action( 'admin_menu', [ $this, 'hide_admin_menu_for_customers' ], PHP_INT_MAX ); // Late execution to override other plugins like Jetpack.
 		add_filter( 'admin_bar_menu', [ $this, 'hide_admin_bar_for_customers' ], PHP_INT_MAX ); // Late execution to override other plugins like Jetpack.
+		add_action( 'admin_page_access_denied', [ $this, 'redirect_to_dashboard' ] );
 	}
 
 	/**
@@ -230,5 +231,15 @@ final class Products_User extends Products {
 		}
 
 		return $wp_admin_bar;
+	}
+
+	/**
+	 * Redirect customers to main admin screen if trying to access restricted admin pages.
+	 */
+	public function redirect_to_dashboard() {
+		if ( self::is_listing_customer() ) {
+			\wp_safe_redirect( \get_admin_url() );
+			exit;
+		}
 	}
 }

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -3,10 +3,6 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalMainDashboardButton as MainDashboardButton,
-	__experimentalFullscreenModeClose as FullscreenModeClose,
-} from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 
 /**
@@ -78,17 +74,6 @@ if ( isListing() ) {
 
 // Editor UI changes for listing customers.
 if ( isListingCustomer ) {
-	// For customers, change the default behavior of the full-screen close button.
-	// This normally links back to the post type list, but that page is inaccessible
-	// to customer users.
-	registerPlugin( 'main-dashboard-button-replace', {
-		render: () => (
-			<MainDashboardButton>
-				<FullscreenModeClose href="/wp-admin/" />
-			</MainDashboardButton>
-		),
-	} );
-
 	/**
 	 * Remove the "Mapbox Access Token" sidebar panel from the jetpack/map block.
 	 * We can't really avoid exposing the API token (which is public anyway), but we can


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

`__experimentalMainDashboardButton` is being [deprecated](https://github.com/WordPress/gutenberg/pull/45149), so this PR removes it in favor of a more generalized solution to redirect to the My Account dashboard whenever a listings customer tries to access a page they don't have permissions for.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Log in as a listings customer, or complete a purchase for a self-serve listing product via the self-serve listings block.
3. Try to access any restricted WP admin page, such as a posts list (`/edit.php?post_type=page`). Confirm that you're redirected to the main My Account dashboard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
