### PR TITLE
chore: handle PHP 8.1 deprecation

### DIFF
--- a/includes/class-products.php
+++ b/includes/class-products.php
@@ -158,8 +158,8 @@ class Products {
 	 * Create or delete self-serve listing products.
 	 */
 	public static function create_or_delete_listing_products() {
-		$action = filter_input( INPUT_GET, 'newspack-listings-products', FILTER_SANITIZE_STRING );
-		$nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
+		$action = filter_input( INPUT_GET, 'newspack-listings-products', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$nonce  = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( wp_verify_nonce( $nonce, self::ACTION_NONCE ) && in_array( $action, self::ACTIONS, true ) ) {
 			if ( self::ACTIONS['create'] === $action ) {

--- a/includes/products/class-products-purchase.php
+++ b/includes/products/class-products-purchase.php
@@ -63,7 +63,7 @@ final class Products_Purchase extends Products {
 	 * Handle submission of the purchase form block.
 	 */
 	public function handle_purchase_form() {
-		$purchase_type = filter_input( INPUT_GET, 'listing-purchase-type', FILTER_SANITIZE_STRING );
+		$purchase_type = filter_input( INPUT_GET, 'listing-purchase-type', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		// Only if coming from a non-checkout page.
 		if ( is_checkout() ) {
@@ -79,11 +79,11 @@ final class Products_Purchase extends Products {
 		$is_subscription = 'subscription' === $purchase_type;
 
 		// Get form submission data.
-		$title_single       = filter_input( INPUT_GET, 'listing-title-single', FILTER_SANITIZE_STRING );
-		$single_type        = filter_input( INPUT_GET, 'listing-single-type', FILTER_SANITIZE_STRING );
-		$featured_upgrade   = filter_input( INPUT_GET, 'listing-featured-upgrade', FILTER_SANITIZE_STRING );
-		$title_subscription = filter_input( INPUT_GET, 'listing-title-subscription', FILTER_SANITIZE_STRING );
-		$premium_upgrade    = filter_input( INPUT_GET, 'listing-premium-upgrade', FILTER_SANITIZE_STRING );
+		$title_single       = filter_input( INPUT_GET, 'listing-title-single', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$single_type        = filter_input( INPUT_GET, 'listing-single-type', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$featured_upgrade   = filter_input( INPUT_GET, 'listing-featured-upgrade', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$title_subscription = filter_input( INPUT_GET, 'listing-title-subscription', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$premium_upgrade    = filter_input( INPUT_GET, 'listing-premium-upgrade', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$listing_to_renew   = filter_input( INPUT_GET, 'listing-renew', FILTER_SANITIZE_NUMBER_INT );
 		$listing_title      = __( 'Untitled listing', 'newspack-listings' );
 
@@ -204,7 +204,7 @@ final class Products_Purchase extends Products {
 	 * Show listing details in checkout summary.
 	 */
 	public function listing_details_summary() {
-		$params        = filter_input_array( INPUT_GET, FILTER_SANITIZE_STRING );
+		$params        = filter_input_array( INPUT_GET, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$listing_title = isset( $params['listing-title'] ) ? $params['listing-title'] : null;
 		$is_renewal    = isset( $params['listing_renewed'] ) ? $params['listing_renewed'] : false;
 		$listing_types = self::get_listing_types();
@@ -265,7 +265,7 @@ final class Products_Purchase extends Products {
 	 * @param Array $form_fields WC form fields.
 	 */
 	public function listing_details_billing_fields( $form_fields ) {
-		$params = filter_input_array( INPUT_GET, FILTER_SANITIZE_STRING );
+		$params = filter_input_array( INPUT_GET, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$fields = array_keys( self::ORDER_META_KEYS );
 
 		if ( is_array( $params ) ) {
@@ -291,7 +291,7 @@ final class Products_Purchase extends Products {
 	 * @param String $order_id WC order id.
 	 */
 	public function listing_checkout_update_order_meta( $order_id ) {
-		$params = filter_input_array( INPUT_POST, FILTER_SANITIZE_STRING );
+		$params = filter_input_array( INPUT_POST, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( is_array( $params ) ) {
 			foreach ( $params as $param => $value ) {

--- a/includes/products/class-products-ui.php
+++ b/includes/products/class-products-ui.php
@@ -528,12 +528,16 @@ final class Products_Ui extends Products {
 	 * Intercept GET params and create a Marketplace or Event listing for a premium subscription.
 	 */
 	public function create_or_delete_premium_listing() {
-		$nonce           = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
-		$customer_id     = filter_input( INPUT_GET, 'customer_id', FILTER_SANITIZE_STRING );
-		$subscription_id = filter_input( INPUT_GET, 'subscription_id', FILTER_SANITIZE_STRING );
-		$post_type_slug  = filter_input( INPUT_GET, 'create', FILTER_SANITIZE_STRING );
+		$nonce           = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$customer_id     = filter_input( INPUT_GET, 'customer_id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$subscription_id = filter_input( INPUT_GET, 'subscription_id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$post_type_slug  = filter_input( INPUT_GET, 'create', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$delete_post     = filter_input( INPUT_GET, 'delete', FILTER_SANITIZE_NUMBER_INT );
-		$redirect_uri    = urldecode( filter_input( INPUT_GET, 'redirect_uri', FILTER_SANITIZE_STRING ) );
+		$redirect_uri    = filter_input( INPUT_GET, 'redirect_uri', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+
+		if ( $redirect_uri ) {
+			$redirect_uri = urldecode( $redirect_uri );
+		}
 
 		// Only if we have all of the required query args.
 		if ( ! $customer_id || ! $subscription_id || ( ! $delete_post && 'event' !== $post_type_slug && 'marketplace' !== $post_type_slug ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Similar to https://github.com/Automattic/newspack-popups/pull/1013, replaces the soon-to-be-deprecated `FILTER_SANITIZE_STRING` with `FILTER_SANITIZE_FULL_SPECIAL_CHARS` in anticipation of PHP 8.1.

### How to test the changes in this Pull Request:

No functional changes, but when running the plugin on PHP >= 8.1, the following warnings on `master` should be fixed:

```
PHP Deprecated:  Constant FILTER_SANITIZE_STRING is deprecated in /Users/dkoo/Local Sites/newspack/app/public/wp-content/plugins/newspack-listings/includes/products/class-products-purchase.php on line 66
```

```
PHP Deprecated:  urldecode(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/dkoo/Local Sites/newspack/app/public/wp-content/plugins/newspack-listings/includes/products/class-products-ui.php on line 536
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
