### PR TITLE
chore: remove unused config file

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-	plugins: {
-		autoprefixer: {},
-	},
-};


### PR DESCRIPTION
Removes the `postcss.config.js` file, which is not used. `newspack-scripts`'s PostCSS config is used when building CSS.