### PR TITLE
fix: accommodate any valid date string in newspack_listings_expiration_date

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -931,18 +931,13 @@ final class Core {
 		}
 
 		$expiration_date = get_post_meta( $post_id, 'newspack_listings_expiration_date', true );
-		if ( ! $expiration_date || ! Utils\is_valid_date_string( $expiration_date ) ) {
+		if ( ! $expiration_date ) {
 			return false;
 		}
 
-		$timezone = get_option( 'timezone_string', 'UTC' );
+		$date_time = Utils\convert_string_to_date_time( $expiration_date );
 
-		// Guard against 'Unknown or bad timezone' PHP error.
-		if ( empty( trim( $timezone ) ) ) {
-			$timezone = 'UTC';
-		}
-
-		return new \DateTime( $expiration_date, new \DateTimeZone( $timezone ) );
+		return $date_time;
 	}
 
 	/**
@@ -973,6 +968,7 @@ final class Core {
 	 * @param int $post_id Post ID to check.
 	 */
 	public static function expire_single_listing( $post_id ) {
+
 		if ( null === $post_id ) {
 			return false;
 		}

--- a/includes/class-featured.php
+++ b/includes/class-featured.php
@@ -440,7 +440,7 @@ final class Featured {
 		self::update_priority( $post_id, $priority );
 
 		// Set expiration, if given and a valid time string.
-		if ( $expires && Utils\is_valid_date_string( $expires ) ) {
+		if ( $expires && false !== Utils\convert_string_to_date_time( $expires ) ) {
 			update_post_meta( $post_id, self::META_KEYS['expires'], $expires );
 		}
 	}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -447,15 +447,30 @@ function all_posts_are_type( $post_type = 'post' ) {
 }
 
 /**
- * Checks a string to see if it's in valid YYYY-MM-DDT00:00:00 format.
- * This is the format we expect to see expiration dates saved as post meta.
+ * Converts a date string into a DateTime object in the site's time zone.
  *
  * @param string $str String to validate.
  *
- * @return boolean True if a valid date in the expected format, false otherwise.
+ * @return DateTime|boolean The DateTime object, or false if $str can't be converted.
  */
-function is_valid_date_string( $str ) {
-	return false !== \DateTime::createFromFormat( 'Y-m-d\TH:i:s', $str );
+function convert_string_to_date_time( $str ) {
+	$unix = strtotime( $str );
+
+	if ( ! $unix ) {
+		return false;
+	}
+
+	$timezone = get_option( 'timezone_string', 'UTC' );
+
+	// Guard against 'Unknown or bad timezone' PHP error.
+	if ( empty( trim( $timezone ) ) ) {
+		$timezone = 'UTC';
+	}
+
+	$date = new \DateTime( null, new \DateTimeZone( $timezone ) );
+	$date->setTimestamp( $unix );
+
+	return $date;
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The Listings editor UI stores expiration date meta fields in `YYYY-MM-DDT00:00:00` format, but this field can sometimes be populated by other automations in different formats.

Instead of expecting all expiration date meta fields to be in `YYYY-MM-DDT00:00:00` format, this fix now allows this meta field to be stored in any valid date string format which can be converted to UNIX time using [`strtotime`](https://www.php.net/manual/en/function.strtotime.php).

Closes `1203869877018965/1204006619447975`.

### How to test the changes in this Pull Request:

1. Publish a listing of any time and set the publish date to sometime in the past.
2. Using WP CLI, set the expiration date meta field to a date string in the more recent past but that's not the expected format: `wp post meta update [post ID] newspack_listings_expiration_date '2023-02-13 17:24:34-05:00'`
3. Using WP CLI, trigger the cron job to expire listings whose expiration dates have passed: `wp cron event run newspack_expire_listings_with_date`
4. On `master`, observe that the listing is not unpublished by the cron job (because the date string isn't in the expected format)
5. Check out this branch, run the cron job again, and confirm that now it is unpublished.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
