### PR TITLE
fix: add pre push hook

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+if [[ "$branch" = "master" ]]; then
+    echo "Error: pushing directly to the master branch is prohibited"
+    exit 1
+fi

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 			"pre-commit": [
 				"./node_modules/.bin/lint-staged"
 			],
+			"pre-push": "./.hooks/pre-push",
 			"commit-msg": [
 				"cat $1 | ./node_modules/.bin/newspack-scripts commitlint"
 			]

--- a/package.json
+++ b/package.json
@@ -1,51 +1,51 @@
 {
-  "name": "newspack-listings",
-  "version": "2.12.5",
-  "description": "",
-  "scripts": {
-    "cm": "newspack-scripts commit",
-    "semantic-release": "newspack-scripts release --files=newspack-listings.php",
-    "start": "npm ci && newspack-scripts watch",
-    "watch": "newspack-scripts watch",
-    "build": "newspack-scripts build",
-    "test": "echo \"Error: no test specified\" && exit 0",
-    "clean": "rm -rf dist/",
-    "lint": "npm run lint:scss && npm run lint:js",
-    "lint:js": "eslint --ext .js,.jsx src",
-    "lint:js:staged": "eslint --ext .js,.jsx",
-    "lint:php:staged": "./vendor/bin/phpcs",
-    "lint:scss": "stylelint '**/*.scss' --customSyntax postcss-scss --config=./node_modules/newspack-scripts/config/stylelint.config.js",
-    "lint:scss:staged": "stylelint --customSyntax postcss-scss --config=./node_modules/newspack-scripts/config/stylelint.config.js",
-    "format:js": "prettier 'src/**/*.{js,jsx}' --write",
-    "format:scss": "prettier --write 'src/**/*.scss'",
-    "format:php": "./vendor/bin/phpcbf .",
-    "release:archive": "rm -rf release && mkdir -p release && rsync -r . ./release/newspack-listings --exclude-from='./.distignore' && cd release && zip -r newspack-listings.zip newspack-listings",
-    "release": "npm run build && npm run semantic-release"
-  },
-  "lint-staged": {
-    "*.js": "npm run lint:js:staged",
-    "*.scss": "npm run lint:scss:staged",
-    "*.php": "npm run lint:php:staged"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Automattic/newspack-listings.git"
-  },
-  "license": "GPL-2.0-or-later",
-  "bugs": {
-    "url": "https://github.com/Automattic/newspack-listings/issues"
-  },
-  "dependencies": {
-    "newspack-components": "^2.1.0"
-  },
-  "devDependencies": {
-    "@rushstack/eslint-patch": "^1.2.0",
-    "eslint": "^7.32.0",
-    "lint-staged": "^13.2.0",
-    "newspack-scripts": "^5.1.0",
-    "postcss": "^8.4.21",
-    "postcss-scss": "^4.0.6",
-    "prettier": "npm:wp-prettier@^2.6.2-beta-1",
-    "stylelint": "^15.4.0"
-  }
+	"name": "newspack-listings",
+	"version": "2.12.5",
+	"description": "",
+	"scripts": {
+		"cm": "newspack-scripts commit",
+		"semantic-release": "newspack-scripts release --files=newspack-listings.php",
+		"start": "npm ci && newspack-scripts watch",
+		"watch": "newspack-scripts watch",
+		"build": "newspack-scripts build",
+		"test": "echo \"Error: no test specified\" && exit 0",
+		"clean": "rm -rf dist/",
+		"lint": "npm run lint:scss && npm run lint:js",
+		"lint:js": "eslint --ext .js,.jsx src",
+		"lint:js:staged": "eslint --ext .js,.jsx",
+		"lint:php:staged": "./vendor/bin/phpcs --filter=GitStaged",
+		"lint:scss": "stylelint '**/*.scss' --customSyntax postcss-scss --config=./node_modules/newspack-scripts/config/stylelint.config.js",
+		"lint:scss:staged": "stylelint --customSyntax postcss-scss --config=./node_modules/newspack-scripts/config/stylelint.config.js",
+		"format:js": "prettier 'src/**/*.{js,jsx}' --write",
+		"format:scss": "prettier --write 'src/**/*.scss'",
+		"format:php": "./vendor/bin/phpcbf .",
+		"release:archive": "rm -rf release && mkdir -p release && rsync -r . ./release/newspack-listings --exclude-from='./.distignore' && cd release && zip -r newspack-listings.zip newspack-listings",
+		"release": "npm run build && npm run semantic-release"
+	},
+	"lint-staged": {
+		"*.js": "npm run lint:js:staged",
+		"*.scss": "npm run lint:scss:staged",
+		"*.php": "npm run lint:php:staged"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/newspack-listings.git"
+	},
+	"license": "GPL-2.0-or-later",
+	"bugs": {
+		"url": "https://github.com/Automattic/newspack-listings/issues"
+	},
+	"dependencies": {
+		"newspack-components": "^2.1.0"
+	},
+	"devDependencies": {
+		"@rushstack/eslint-patch": "^1.2.0",
+		"eslint": "^7.32.0",
+		"lint-staged": "^13.2.0",
+		"newspack-scripts": "^5.1.0",
+		"postcss": "^8.4.21",
+		"postcss-scss": "^4.0.6",
+		"prettier": "npm:wp-prettier@^2.6.2-beta-1",
+		"stylelint": "^15.4.0"
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Prevents direct pushes to master.

### How to test the changes in this Pull Request:

1. Run composer install
2. Commit something to master
3. try to push and see the error message

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->