### PR TITLE
fix: only run self-serve-related actions if enabled

### DIFF
--- a/includes/class-products.php
+++ b/includes/class-products.php
@@ -89,13 +89,15 @@ class Products {
 	 * Initialize self-serve listings features.
 	 */
 	public static function init() {
-		// WP actions to create the necessary products, and to handle submission of the Self-Serve Listings block form.
-		add_action( 'woocommerce_after_register_post_type', [ __CLASS__, 'setup' ] );
-		add_action( 'wp_loaded', [ __CLASS__, 'create_or_delete_listing_products' ], 99 );
+		if ( self::is_active() ) {
+			// WP actions to create the necessary products, and to handle submission of the Self-Serve Listings block form.
+			add_action( 'woocommerce_after_register_post_type', [ __CLASS__, 'setup' ] );
+			add_action( 'wp_loaded', [ __CLASS__, 'create_or_delete_listing_products' ], 99 );
 
-		// When product settings are updated, make sure to update the corresponding WooCommerce products as well.
-		add_action( 'update_option', [ __CLASS__, 'update_products' ], 10, 3 );
-		add_action( 'updated_post_meta', [ __CLASS__, 'update_product_option' ], 10, 4 );
+			// When product settings are updated, make sure to update the corresponding WooCommerce products as well.
+			add_action( 'update_option', [ __CLASS__, 'update_products' ], 10, 3 );
+			add_action( 'updated_post_meta', [ __CLASS__, 'update_product_option' ], 10, 4 );
+		}
 	}
 
 	/**

--- a/includes/class-products.php
+++ b/includes/class-products.php
@@ -89,15 +89,13 @@ class Products {
 	 * Initialize self-serve listings features.
 	 */
 	public static function init() {
-		if ( self::is_active() ) {
-			// WP actions to create the necessary products, and to handle submission of the Self-Serve Listings block form.
-			add_action( 'woocommerce_after_register_post_type', [ __CLASS__, 'setup' ] );
-			add_action( 'wp_loaded', [ __CLASS__, 'create_or_delete_listing_products' ], 99 );
+		// WP actions to create the necessary products, and to handle submission of the Self-Serve Listings block form.
+		add_action( 'woocommerce_after_register_post_type', [ __CLASS__, 'setup' ] );
+		add_action( 'wp_loaded', [ __CLASS__, 'create_or_delete_listing_products' ], 99 );
 
-			// When product settings are updated, make sure to update the corresponding WooCommerce products as well.
-			add_action( 'update_option', [ __CLASS__, 'update_products' ], 10, 3 );
-			add_action( 'updated_post_meta', [ __CLASS__, 'update_product_option' ], 10, 4 );
-		}
+		// When product settings are updated, make sure to update the corresponding WooCommerce products as well.
+		add_action( 'update_option', [ __CLASS__, 'update_products' ], 10, 3 );
+		add_action( 'updated_post_meta', [ __CLASS__, 'update_product_option' ], 10, 4 );
 	}
 
 	/**
@@ -299,6 +297,10 @@ class Products {
 	 * @param mixed  $new_value The new option value.
 	 */
 	public static function update_products( $option, $old_value, $new_value ) {
+		if ( ! self::is_active() ) {
+			return;
+		}
+
 		// Only if the updated option is a Newspack Listing setting.
 		$settings = Settings::get_settings();
 		if ( ! in_array( $option, array_keys( $settings ) ) ) {
@@ -343,6 +345,11 @@ class Products {
 	 * @param mixed  $meta_value Value of $meta_key.
 	 */
 	public static function update_product_option( $meta_id, $post_id, $meta_key, $meta_value ) {
+		// Only run if self-serve listings are enabled.
+		if ( ! self::is_active() ) {
+			return;
+		}
+
 		// Only run if post being updated is a product and meta field being updated is '_price'.
 		if ( 'product' !== get_post_type( $post_id ) || '_price' !== $meta_key ) {
 			return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If self-serve listings features are not enabled, the `Products` class will still run some of its actions, which can result in errors in some cases. This PR prevents those actions from running if self-serve features are disabled.

### How to test the changes in this Pull Request:

1. Make sure your `wp-config.php` does not have the `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` constant, or that it's set to `false`.
2. On `release`, add an `error_log( 'test' )` line to output something in the `update_products` method [here](https://github.com/Automattic/newspack-listings/blob/master/includes/class-products.php#L299).
3. Go to Listings > Settings and save. Observe that your `error_log` executes even though self-serve features are disabled.
4. Check out this branch and repeat step 3. Confirm that the method does not execute now unless the `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` flag is turned on.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
