### PR TITLE
feat: add POT file to Listings plugin

### DIFF
--- a/languages/newspack-listings.pot
+++ b/languages/newspack-listings.pot
@@ -1,0 +1,1497 @@
+# Copyright (C) 2023 Automattic
+# This file is distributed under the same license as the Newspack Listings plugin.
+msgid ""
+msgstr ""
+"Project-Id-Version: Newspack Listings 2.12.8\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/newspack-listings\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2023-05-31T01:38:27+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.5.0\n"
+"X-Domain: newspack-listings\n"
+
+#. Plugin Name of the plugin
+#: includes/class-block-patterns.php:61
+#: dist/editor.js:33
+#: src/editor/sidebar/index.js:48
+msgid "Newspack Listings"
+msgstr ""
+
+#. Plugin URI of the plugin
+#. Author URI of the plugin
+msgid "https://newspack.pub"
+msgstr ""
+
+#. Description of the plugin
+msgid "Listings and directories for Newspack sites."
+msgstr ""
+
+#. Author of the plugin
+msgid "Automattic"
+msgstr ""
+
+#: includes/class-api.php:162
+msgid "You cannot use this resource."
+msgstr ""
+
+#: includes/class-block-patterns.php:78
+msgid "Business Listing 1"
+msgstr ""
+
+#: includes/class-block-patterns.php:80
+#: includes/class-block-patterns.php:93
+#: includes/class-block-patterns.php:107
+#: includes/class-block-patterns.php:120
+#: includes/class-block-patterns.php:133
+msgctxt "Block pattern description"
+msgid "Business description, map, contact info, and hours of operation."
+msgstr ""
+
+#: includes/class-block-patterns.php:91
+msgid "Business Listing 2"
+msgstr ""
+
+#: includes/class-block-patterns.php:105
+msgid "Business Listing 3"
+msgstr ""
+
+#: includes/class-block-patterns.php:118
+msgid "Business Listing 4"
+msgstr ""
+
+#: includes/class-block-patterns.php:131
+msgid "Business Listing 5"
+msgstr ""
+
+#: includes/class-block-patterns.php:144
+msgid "Real Estate Listing 1"
+msgstr ""
+
+#: includes/class-block-patterns.php:146
+#: includes/class-block-patterns.php:159
+#: includes/class-block-patterns.php:172
+msgctxt "Block pattern description"
+msgid "Real estate listing with price, address, image slideshow, property info, description, and map."
+msgstr ""
+
+#: includes/class-block-patterns.php:157
+msgid "Real Estate Listing 2"
+msgstr ""
+
+#: includes/class-block-patterns.php:170
+msgid "Real Estate Listing 3"
+msgstr ""
+
+#: includes/class-block-patterns.php:183
+msgid "Classified Ad 1"
+msgstr ""
+
+#: includes/class-block-patterns.php:185
+#: includes/class-block-patterns.php:198
+msgctxt "Block pattern description"
+msgid "Classified ad with images, description and price."
+msgstr ""
+
+#: includes/class-block-patterns.php:196
+msgid "Classified Ad 2"
+msgstr ""
+
+#: includes/class-blocks.php:85
+msgid "USD"
+msgstr ""
+
+#: includes/class-blocks.php:86
+msgid "United States (US) dollar"
+msgstr ""
+
+#: includes/class-core.php:114
+msgid "Newspack Listings: Categories"
+msgstr ""
+
+#: includes/class-core.php:115
+msgid "Categories"
+msgstr ""
+
+#: includes/class-core.php:121
+msgid "Newspack Listings: Tags"
+msgstr ""
+
+#: includes/class-core.php:122
+msgid "Tags"
+msgstr ""
+
+#: includes/class-core.php:130
+#: includes/class-settings.php:315
+msgid "Newspack Listings: Site-Wide Settings"
+msgstr ""
+
+#: includes/class-core.php:131
+msgid "Settings"
+msgstr ""
+
+#: includes/class-core.php:177
+msgctxt "post type general name"
+msgid "Events"
+msgstr ""
+
+#: includes/class-core.php:178
+msgctxt "post type singular name"
+msgid "Event"
+msgstr ""
+
+#: includes/class-core.php:179
+msgctxt "admin menu"
+msgid "Events"
+msgstr ""
+
+#: includes/class-core.php:180
+msgctxt "add new on admin bar"
+msgid "Event"
+msgstr ""
+
+#: includes/class-core.php:181
+#: includes/class-core.php:201
+#: includes/class-core.php:220
+#: includes/class-core.php:239
+msgctxt "popup"
+msgid "Add New"
+msgstr ""
+
+#: includes/class-core.php:182
+msgid "Add New Event"
+msgstr ""
+
+#: includes/class-core.php:183
+msgid "New Event"
+msgstr ""
+
+#: includes/class-core.php:184
+msgid "Edit Event"
+msgstr ""
+
+#: includes/class-core.php:185
+msgid "View Event"
+msgstr ""
+
+#: includes/class-core.php:186
+msgid "Events"
+msgstr ""
+
+#: includes/class-core.php:187
+msgid "Search Events"
+msgstr ""
+
+#: includes/class-core.php:188
+msgid "Parent Event:"
+msgstr ""
+
+#: includes/class-core.php:189
+msgid "No events found."
+msgstr ""
+
+#: includes/class-core.php:190
+msgid "No events found in Trash."
+msgstr ""
+
+#: includes/class-core.php:197
+msgctxt "post type general name"
+msgid "Generic Listings"
+msgstr ""
+
+#: includes/class-core.php:198
+msgctxt "post type singular name"
+msgid "Generic Listing"
+msgstr ""
+
+#: includes/class-core.php:199
+msgctxt "admin menu"
+msgid "Generic Listings"
+msgstr ""
+
+#: includes/class-core.php:200
+msgctxt "add new on admin bar"
+msgid "Generic Listing"
+msgstr ""
+
+#: includes/class-core.php:202
+msgid "Add New Generic Listing"
+msgstr ""
+
+#: includes/class-core.php:203
+msgid "New Generic Listing"
+msgstr ""
+
+#: includes/class-core.php:204
+msgid "Edit Generic Listing"
+msgstr ""
+
+#: includes/class-core.php:205
+msgid "View Generic Listing"
+msgstr ""
+
+#: includes/class-core.php:206
+msgid "Generic Listings"
+msgstr ""
+
+#: includes/class-core.php:207
+msgid "Search Generic Listings"
+msgstr ""
+
+#: includes/class-core.php:208
+msgid "Parent Generic Listing:"
+msgstr ""
+
+#: includes/class-core.php:209
+msgid "No generic listings found."
+msgstr ""
+
+#: includes/class-core.php:210
+msgid "No generic listings found in Trash."
+msgstr ""
+
+#: includes/class-core.php:216
+msgctxt "post type general name"
+msgid "Marketplace"
+msgstr ""
+
+#: includes/class-core.php:217
+msgctxt "post type singular name"
+msgid "Marketplace Listing"
+msgstr ""
+
+#: includes/class-core.php:218
+msgctxt "admin menu"
+msgid "Marketplace Listings"
+msgstr ""
+
+#: includes/class-core.php:219
+msgctxt "add new on admin bar"
+msgid "Marketplace Listing"
+msgstr ""
+
+#: includes/class-core.php:221
+msgid "Add New Marketplace Listing"
+msgstr ""
+
+#: includes/class-core.php:222
+msgid "New Marketplace Listing"
+msgstr ""
+
+#: includes/class-core.php:223
+msgid "Edit Marketplace Listing"
+msgstr ""
+
+#: includes/class-core.php:224
+msgid "View Marketplace Listing"
+msgstr ""
+
+#: includes/class-core.php:225
+msgid "Marketplace Listings"
+msgstr ""
+
+#: includes/class-core.php:226
+msgid "Search Marketplace Listings"
+msgstr ""
+
+#: includes/class-core.php:227
+msgid "Parent Marketplace Listing:"
+msgstr ""
+
+#: includes/class-core.php:228
+msgid "No Marketplace listings found."
+msgstr ""
+
+#: includes/class-core.php:229
+msgid "No Marketplace listings found in Trash."
+msgstr ""
+
+#: includes/class-core.php:235
+msgctxt "post type general name"
+msgid "Places"
+msgstr ""
+
+#: includes/class-core.php:236
+msgctxt "post type singular name"
+msgid "Place"
+msgstr ""
+
+#: includes/class-core.php:237
+msgctxt "admin menu"
+msgid "Places"
+msgstr ""
+
+#: includes/class-core.php:238
+msgctxt "add new on admin bar"
+msgid "Place"
+msgstr ""
+
+#: includes/class-core.php:240
+msgid "Add New Place"
+msgstr ""
+
+#: includes/class-core.php:241
+msgid "New Place"
+msgstr ""
+
+#: includes/class-core.php:242
+msgid "Edit Place"
+msgstr ""
+
+#: includes/class-core.php:243
+msgid "View Place"
+msgstr ""
+
+#: includes/class-core.php:244
+msgid "Places"
+msgstr ""
+
+#: includes/class-core.php:245
+msgid "Search Places"
+msgstr ""
+
+#: includes/class-core.php:246
+msgid "Parent Place:"
+msgstr ""
+
+#: includes/class-core.php:247
+msgid "No places found."
+msgstr ""
+
+#: includes/class-core.php:248
+msgid "No places found in Trash."
+msgstr ""
+
+#: includes/class-core.php:296
+msgid "Template"
+msgstr ""
+
+#: includes/class-core.php:314
+#: dist/editor.js:33
+#: src/editor/featured-listings/index.js:157
+#: src/editor/sidebar/index.js:93
+msgid "Expiration Date"
+msgstr ""
+
+#: includes/class-core.php:332
+msgid "Contact email address"
+msgstr ""
+
+#: includes/class-core.php:340
+msgid "Email address to contact for this listing."
+msgstr ""
+
+#: includes/class-core.php:355
+msgid "Contact phone number"
+msgstr ""
+
+#: includes/class-core.php:363
+msgid "Phone number to contact for this listing."
+msgstr ""
+
+#: includes/class-core.php:385
+msgid "Contact Address"
+msgstr ""
+
+#: includes/class-core.php:390
+msgid "Contact address for this listing."
+msgstr ""
+
+#: includes/class-core.php:403
+msgid "Hours of Operation"
+msgstr ""
+
+#: includes/class-core.php:411
+msgid "Hours of operation for this listing."
+msgstr ""
+
+#: includes/class-core.php:425
+msgid "Locations"
+msgstr ""
+
+#: includes/class-core.php:433
+msgid "Geolocation data for this listing."
+msgstr ""
+
+#: includes/class-core.php:445
+msgid "Event dates"
+msgstr ""
+
+#: includes/class-core.php:454
+msgid "Start date for this event."
+msgstr ""
+
+#: includes/class-core.php:466
+#: src/blocks/price/edit.js:82
+#: src/blocks/price/index.js:17
+msgid "Price"
+msgstr ""
+
+#: includes/class-core.php:475
+msgid "Price for this listing."
+msgstr ""
+
+#: includes/class-core.php:490
+#: dist/editor.js:33
+#: src/editor/sidebar/index.js:62
+msgid "Hide listing author"
+msgstr ""
+
+#: includes/class-core.php:494
+msgid "Hide author byline and bio for this listing"
+msgstr ""
+
+#: includes/class-core.php:509
+#: includes/class-core.php:513
+msgid "Images associated with this listing."
+msgstr ""
+
+#: includes/class-core.php:528
+#: dist/editor.js:33
+#: src/editor/sidebar/index.js:75
+msgid "Hide publish date"
+msgstr ""
+
+#: includes/class-core.php:532
+msgid "Hide publish and updated dates for this listing"
+msgstr ""
+
+#: includes/class-core.php:549
+msgid "Hide parent listings"
+msgstr ""
+
+#: includes/class-core.php:553
+msgid "Hide parent listings assigned to this post"
+msgstr ""
+
+#: includes/class-core.php:570
+msgid "Hide child listings"
+msgstr ""
+
+#: includes/class-core.php:574
+msgid "Hide child listings assigned to this post"
+msgstr ""
+
+#. Translators: error message logged when we're unable to expire a listing via cron job.
+#: includes/class-core.php:988
+#: includes/products/class-products-cron.php:133
+msgid "Newspack Listings: Error expiring listing with ID %d."
+msgstr ""
+
+#: includes/class-featured.php:257
+msgid "Is this listing a featured listing?"
+msgstr ""
+
+#: includes/class-featured.php:266
+msgid "When should the listing’s featured status expire?"
+msgstr ""
+
+#: includes/class-products.php:184
+msgid "Self-Serve Listings"
+msgstr ""
+
+#. translators: %s: Product name
+#: includes/class-products.php:198
+msgid "Single Listing"
+msgstr ""
+
+#. translators: %s: Product name
+#: includes/class-products.php:210
+msgid "“Featured” Listing Upgrade"
+msgstr ""
+
+#. translators: %s: Product name
+#: includes/class-products.php:222
+msgid "Listing Subscription"
+msgstr ""
+
+#. translators: %s: Product name
+#: includes/class-products.php:237
+msgid "Premium Subscription Upgrade"
+msgstr ""
+
+#: includes/class-products.php:390
+msgid "Missing or invalid self-serve listing parent product."
+msgstr ""
+
+#: includes/class-products.php:408
+msgid "Missing or invalid self-serve listing child products."
+msgstr ""
+
+#: includes/class-products.php:431
+msgid "Blank listing (start from scratch)"
+msgstr ""
+
+#: includes/class-products.php:435
+msgid "Event"
+msgstr ""
+
+#: includes/class-products.php:439
+msgid "Classified Ad"
+msgstr ""
+
+#: includes/class-products.php:443
+msgid "Job Listing"
+msgstr ""
+
+#: includes/class-products.php:447
+msgid "Real Estate Listing"
+msgstr ""
+
+#: includes/class-settings.php:38
+msgid "Permalink Settings"
+msgstr ""
+
+#: includes/class-settings.php:42
+msgid "Automated Directory Settings"
+msgstr ""
+
+#: includes/class-settings.php:46
+msgid "Post Meta Settings"
+msgstr ""
+
+#: includes/class-settings.php:54
+msgid "Self-Serve Settings"
+msgstr ""
+
+#: includes/class-settings.php:63
+msgid "Related Content Settings"
+msgstr ""
+
+#. Translators: instructions on how to fix missing self-serve products.
+#: includes/class-settings.php:86
+msgid "Self-serve listing features are %1$s. <a href=\"%2$s\">Click here to %3$s self-serve listings features on this site</a>.%4$s"
+msgstr ""
+
+#: includes/class-settings.php:87
+msgid "active"
+msgstr ""
+
+#: includes/class-settings.php:87
+msgid "not active"
+msgstr ""
+
+#: includes/class-settings.php:89
+msgid "disable"
+msgstr ""
+
+#: includes/class-settings.php:89
+msgid "enable"
+msgstr ""
+
+#: includes/class-settings.php:90
+msgid " <b>Warning:</b> Disabling will cancel all existing self-serve listing subscriptions."
+msgstr ""
+
+#: includes/class-settings.php:104
+msgid "The URL prefix for all listings. This prefix will appear before the listing slug in all listing URLs."
+msgstr ""
+
+#: includes/class-settings.php:106
+msgid "Listings permalink prefix"
+msgstr ""
+
+#: includes/class-settings.php:108
+#: src/blocks/curated-list/index.js:29
+#: src/blocks/event-dates/index.js:27
+#: src/blocks/list-container/index.js:31
+#: src/blocks/listing/index.js:33
+#: src/blocks/price/index.js:27
+#: src/blocks/self-serve-listings/index.js:25
+msgid "listings"
+msgstr ""
+
+#: includes/class-settings.php:113
+msgid "The URL slug for event listings."
+msgstr ""
+
+#: includes/class-settings.php:115
+msgid "Event listings slug"
+msgstr ""
+
+#: includes/class-settings.php:117
+#: src/blocks/event-dates/index.js:30
+msgid "events"
+msgstr ""
+
+#: includes/class-settings.php:121
+msgid "The URL slug for generic listings."
+msgstr ""
+
+#: includes/class-settings.php:123
+msgid "Generic listings slug"
+msgstr ""
+
+#: includes/class-settings.php:125
+msgid "items"
+msgstr ""
+
+#: includes/class-settings.php:129
+msgid "The URL slug for marketplace listings."
+msgstr ""
+
+#: includes/class-settings.php:131
+msgid "Marketplace listings slug"
+msgstr ""
+
+#: includes/class-settings.php:133
+#: includes/products/class-products-ui.php:572
+msgid "marketplace"
+msgstr ""
+
+#: includes/class-settings.php:137
+msgid "The URL slug for place listings."
+msgstr ""
+
+#: includes/class-settings.php:139
+msgid "Place listings slug"
+msgstr ""
+
+#: includes/class-settings.php:141
+msgid "places"
+msgstr ""
+
+#: includes/class-settings.php:145
+msgid "Enables automated archives for each listing type. Archives will use the permalink slugs set above."
+msgstr ""
+
+#: includes/class-settings.php:153
+msgid "Allows listings to appear in automated category and tag archives."
+msgstr ""
+
+#: includes/class-settings.php:161
+msgid "If listing archives are enabled, shows listings-only archives in a grid-like layout."
+msgstr ""
+
+#: includes/class-settings.php:169
+#: includes/class-settings.php:177
+msgid "This setting can be overridden per listing."
+msgstr ""
+
+#: includes/class-settings.php:185
+msgid "Disables Yoast primary category functionality for all listings."
+msgstr ""
+
+#: includes/class-settings.php:197
+msgid "Hide <a href=\"/wp-admin/admin.php?page=jetpack#/traffic\">Jetpack’s Related Posts module</a> on individual listing pages."
+msgstr ""
+
+#: includes/class-settings.php:211
+msgid "The base price for a single listing (no subscription)."
+msgstr ""
+
+#: includes/class-settings.php:220
+msgid "The upgrade price to make a single-purchase listing \"featured.\""
+msgstr ""
+
+#: includes/class-settings.php:230
+msgid "The number of days a single listing purchase remains live after being published. Set this value to 0 to allow purchased listings to remain live indefinitely."
+msgstr ""
+
+#: includes/class-settings.php:239
+msgid "The base monthly subscription price. This fee is charged monthly."
+msgstr ""
+
+#: includes/class-settings.php:248
+msgid "The upgrade price for a premium subscription, which allows subscribers to create up to 10 additional Marketplace or Event listings. This fee is charged monthly."
+msgstr ""
+
+#. translators: %s: Settings key being requested
+#: includes/class-settings.php:299
+msgid "The settings key “%s” does not exist."
+msgstr ""
+
+#: includes/importer/class-importer.php:495
+#: src/blocks/listing/edit.js:117
+#: src/blocks/listing/edit.js:138
+msgid "(no title)"
+msgstr ""
+
+#: includes/products/class-products-purchase.php:88
+#: includes/products/class-products-purchase.php:338
+msgid "Untitled listing"
+msgstr ""
+
+#: includes/products/class-products-purchase.php:223
+#: includes/products/class-products-ui.php:258
+#: src/templates/self-serve-form.php:77
+#: src/templates/self-serve-form.php:153
+#: src/blocks/self-serve-listings/edit.js:199
+#: src/blocks/self-serve-listings/edit.js:272
+msgid "Listing Details"
+msgstr ""
+
+#. Translators: if renewing, explain what that does.
+#: includes/products/class-products-purchase.php:231
+msgid "The following listing will be extended by %d days:"
+msgstr ""
+
+#: includes/products/class-products-purchase.php:238
+msgid "You can update listing details after purchase."
+msgstr ""
+
+#: includes/products/class-products-purchase.php:246
+msgid "Listing Title: "
+msgstr ""
+
+#: includes/products/class-products-purchase.php:251
+msgid "Listing Type: "
+msgstr ""
+
+#. Translators: error message when we're not able to renew the given post ID.
+#: includes/products/class-products-purchase.php:381
+msgid "Error renewing listing with ID %d. Please contact the site administrators to renew."
+msgstr ""
+
+#: includes/products/class-products-purchase.php:425
+msgid "Error creating a listing for this purchase. Please contact the site administrators to create a listing."
+msgstr ""
+
+#. Translators: edit listing message and link.
+#: includes/products/class-products-purchase.php:466
+msgid " You can now <a href=\"%1$s\">edit your listing</a>%2$s."
+msgstr ""
+
+#. Translators: manage account message and link.
+#: includes/products/class-products-purchase.php:469
+msgid " or <a href=\"%s\">manage your account</a>"
+msgstr ""
+
+#: includes/products/class-products-ui.php:68
+msgid "View Details"
+msgstr ""
+
+#: includes/products/class-products-ui.php:93
+msgid "Renew Listing"
+msgstr ""
+
+#: includes/products/class-products-ui.php:98
+msgid "Edit Listing"
+msgstr ""
+
+#. Translators: view or preview listing button link.
+#: includes/products/class-products-ui.php:104
+msgid "%s Listing"
+msgstr ""
+
+#. Translators: view or preview listing button link.
+#: includes/products/class-products-ui.php:104
+#: includes/products/class-products-ui.php:516
+msgid "View"
+msgstr ""
+
+#. Translators: view or preview listing button link.
+#: includes/products/class-products-ui.php:104
+#: includes/products/class-products-ui.php:516
+msgid "Preview"
+msgstr ""
+
+#: includes/products/class-products-ui.php:116
+msgid "View Original Order"
+msgstr ""
+
+#: includes/products/class-products-ui.php:139
+#: includes/products/class-products-ui.php:489
+msgid "Listing Status"
+msgstr ""
+
+#: includes/products/class-products-ui.php:155
+msgid "Listing not found: please contact the site administrators."
+msgstr ""
+
+#: includes/products/class-products-ui.php:160
+msgid "expired"
+msgstr ""
+
+#: includes/products/class-products-ui.php:171
+msgid "published (expires soon)"
+msgstr ""
+
+#: includes/products/class-products-ui.php:175
+msgid "published"
+msgstr ""
+
+#. Translators: status to output when the current order is not a listing, a.k.a. "not available".
+#: includes/products/class-products-ui.php:213
+msgid "n/a"
+msgstr ""
+
+#: includes/products/class-products-ui.php:262
+msgid "This order was a renewal of an expired listing."
+msgstr ""
+
+#: includes/products/class-products-ui.php:263
+msgid "Click here to view the original order details"
+msgstr ""
+
+#: includes/products/class-products-ui.php:267
+msgid "Listing Title:"
+msgstr ""
+
+#: includes/products/class-products-ui.php:268
+msgid "Listing Status:"
+msgstr ""
+
+#: includes/products/class-products-ui.php:272
+msgid "Your listing has expired and is no longer published."
+msgstr ""
+
+#: includes/products/class-products-ui.php:276
+#: src/blocks/curated-list/edit.js:320
+#: src/blocks/listing/edit.js:191
+msgid "Edit this listing"
+msgstr ""
+
+#. Translators: listing details edit message and link.
+#: includes/products/class-products-ui.php:283
+msgid "to update its content or %s. "
+msgstr ""
+
+#: includes/products/class-products-ui.php:284
+msgid "unpublish it"
+msgstr ""
+
+#: includes/products/class-products-ui.php:284
+msgid "submit it for review"
+msgstr ""
+
+#. Translators: message explaining how many days single-purchase listings are active, and how to renew.
+#: includes/products/class-products-ui.php:312
+msgid "Listings are active for %1$d days after publication by default. %2$sTo extend your listing by an additional %3$s:"
+msgstr ""
+
+#. Translators: If $single_expiration_period is more than one, show the number.
+#: includes/products/class-products-ui.php:317
+msgid "%d days"
+msgstr ""
+
+#: includes/products/class-products-ui.php:318
+msgid "day"
+msgstr ""
+
+#: includes/products/class-products-ui.php:329
+msgid "To quickly purchase a new blank Marketplace listing:"
+msgstr ""
+
+#: includes/products/class-products-ui.php:454
+msgid "Premium subscription listings"
+msgstr ""
+
+#. translators: explanation of premium subscription benefits.
+#: includes/products/class-products-ui.php:460
+msgid "A premium subscription lets you create up to %1$d additional Marketplace or Event listings. %2$s"
+msgstr ""
+
+#. translators: explanation of remaining included listings.
+#: includes/products/class-products-ui.php:464
+msgid "You have %d included listings remaining."
+msgstr ""
+
+#: includes/products/class-products-ui.php:465
+msgid "You don’t have any included listings available. To create additional listings, please purchase them."
+msgstr ""
+
+#: includes/products/class-products-ui.php:476
+msgid "Create New Marketplace Listing"
+msgstr ""
+
+#: includes/products/class-products-ui.php:477
+msgid "Create New Event Listing"
+msgstr ""
+
+#: includes/products/class-products-ui.php:488
+#: src/templates/self-serve-form.php:79
+#: src/templates/self-serve-form.php:155
+#: src/blocks/self-serve-listings/edit.js:201
+#: src/blocks/self-serve-listings/edit.js:274
+msgid "Listing Title"
+msgstr ""
+
+#: includes/products/class-products-ui.php:514
+msgid "Edit"
+msgstr ""
+
+#: includes/products/class-products-ui.php:517
+msgid "Are you sure you want to delete this listing? This cannot be undone."
+msgstr ""
+
+#: includes/products/class-products-ui.php:517
+msgid "Delete"
+msgstr ""
+
+#. translators: default "untitled" listing title.
+#: includes/products/class-products-ui.php:571
+msgid "Untitled %s listing"
+msgstr ""
+
+#: includes/products/class-products-ui.php:572
+#: src/blocks/event-dates/index.js:29
+msgid "event"
+msgstr ""
+
+#: includes/products/class-products-ui.php:588
+msgid "There was an error creating your listing. Please try again or contact the site administrators for help."
+msgstr ""
+
+#: includes/utils.php:522
+msgid "$callback must be callable."
+msgstr ""
+
+#: src/blocks/curated-list/view.php:209
+msgid "Load more listings"
+msgstr ""
+
+#: src/blocks/curated-list/view.php:214
+msgid "Loading..."
+msgstr ""
+
+#: src/blocks/curated-list/view.php:217
+msgid "Something went wrong. Please refresh the page and/or try again."
+msgstr ""
+
+#: src/templates/event-dates.php:64
+msgctxt "Date separator"
+msgid "–"
+msgstr ""
+
+#: src/templates/listing.php:140
+#: src/blocks/listing/listing.js:93
+msgid " and "
+msgstr ""
+
+#: src/templates/listing.php:144
+#: dist/editor.js:33
+#: src/blocks/listing/listing.js:97
+msgctxt "separator character"
+msgid ", "
+msgstr ""
+
+#: src/templates/listing.php:155
+msgid "By"
+msgstr ""
+
+#: src/templates/listing.php:173
+#: src/blocks/listing/listing.js:112
+msgid "Tagged: "
+msgstr ""
+
+#. Translators: user-facing explanation of expiration behavior.
+#: src/templates/self-serve-form.php:66
+#: src/blocks/self-serve-listings/edit.js:190
+msgid "Single-purchase listings expire %d days after the date of publication."
+msgstr ""
+
+#: src/templates/self-serve-form.php:89
+#: src/templates/sort-ui.php:107
+#: src/blocks/self-serve-listings/edit.js:211
+msgid "Listing Type"
+msgstr ""
+
+#: src/templates/self-serve-form.php:114
+#: src/blocks/self-serve-listings/edit.js:226
+msgid "Upgrade to a featured listing"
+msgstr ""
+
+#: src/templates/self-serve-form.php:119
+#: src/blocks/self-serve-listings/edit.js:229
+msgid "Featured listings appear first in lists, directory pages and search results."
+msgstr ""
+
+#: src/templates/self-serve-form.php:150
+#: src/blocks/self-serve-listings/edit.js:266
+msgid "Subscription listings remain live as long as the subscription is active."
+msgstr ""
+
+#: src/templates/self-serve-form.php:170
+#: src/blocks/self-serve-listings/edit.js:289
+msgid "Upgrade to a premium subscription"
+msgstr ""
+
+#: src/templates/self-serve-form.php:175
+#: src/blocks/self-serve-listings/edit.js:292
+msgid "A premium subscription upgrades your listing to \"featured\" status and lets you create up to 10 additional Marketplace or Event listings."
+msgstr ""
+
+#: src/templates/sort-ui.php:63
+#: src/blocks/list-container/edit.js:37
+msgid "Sort by:"
+msgstr ""
+
+#: src/templates/sort-ui.php:70
+msgid "Default"
+msgstr ""
+
+#: src/templates/sort-ui.php:80
+msgid "Event Date"
+msgstr ""
+
+#: src/templates/sort-ui.php:89
+msgid "Publish Date"
+msgstr ""
+
+#: src/templates/sort-ui.php:97
+msgid "Title"
+msgstr ""
+
+#: src/templates/sort-ui.php:118
+msgid "Author"
+msgstr ""
+
+#: src/templates/sort-ui.php:127
+#: src/blocks/list-container/edit.js:55
+msgid "Sort order:"
+msgstr ""
+
+#: src/templates/sort-ui.php:140
+#: src/blocks/list-container/edit.js:68
+msgid "Ascending"
+msgstr ""
+
+#: src/templates/sort-ui.php:154
+#: src/blocks/list-container/edit.js:82
+msgid "Descending"
+msgstr ""
+
+#. Translators: Listing post type sidebar settings label.
+#: dist/editor.js:33
+#: src/editor/sidebar/index.js:47
+msgid "%s Settings"
+msgstr ""
+
+#: dist/editor.js:33
+#: src/editor/sidebar/index.js:53
+msgid "Overrides "
+msgstr ""
+
+#: dist/editor.js:33
+#: src/editor/sidebar/index.js:55
+msgid "global settings"
+msgstr ""
+
+#. Translators: Show or hide author byline toggle label.
+#: dist/editor.js:33
+#: src/editor/sidebar/index.js:65
+msgid "%s the author byline for this listing."
+msgstr ""
+
+#. Translators: Show or hide publish date toggle label.
+#: dist/editor.js:33
+#: src/editor/sidebar/index.js:78
+msgid "%s the publish and updated dates for this listing."
+msgstr ""
+
+#: dist/editor.js:33
+#: src/editor/sidebar/index.js:89
+msgid "If set, the listing will be automatically unpublished after this date."
+msgstr ""
+
+#. Translators: warning when listings customer tries to extend expiration beyond allowed range.
+#: dist/editor.js:33
+#: src/editor/sidebar/index.js:121
+msgid "Cannot set expiration date beyond %s."
+msgstr ""
+
+#: dist/editor.js:33
+#: src/editor/sidebar/index.js:153
+msgid "Expiration date must be after publish date."
+msgstr ""
+
+#. translators: label for small size option
+#: src/blocks/curated-list/edit.js:352
+msgid "Small"
+msgstr ""
+
+#. translators: label for small size option
+#. translators: abbreviation for small size
+#: src/blocks/curated-list/edit.js:353
+msgid "S"
+msgstr ""
+
+#. translators: label for medium size option
+#: src/blocks/curated-list/edit.js:357
+msgid "Medium"
+msgstr ""
+
+#. translators: label for medium size option
+#. translators: abbreviation for medium size
+#: src/blocks/curated-list/edit.js:358
+msgid "M"
+msgstr ""
+
+#. translators: label for large size option
+#: src/blocks/curated-list/edit.js:362
+msgid "Large"
+msgstr ""
+
+#. translators: label for large size option
+#. translators: abbreviation for large size
+#: src/blocks/curated-list/edit.js:363
+msgid "L"
+msgstr ""
+
+#. translators: label for extra large size option
+#: src/blocks/curated-list/edit.js:367
+msgid "Extra Large"
+msgstr ""
+
+#. translators: abbreviation for extra large size
+#: src/blocks/curated-list/edit.js:371
+msgid "XL"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:383
+#: src/blocks/curated-list/edit.js:397
+#: src/blocks/curated-list/index.js:19
+msgid "Curated List"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:414
+msgid "Query"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:419
+msgid "Specific Listings"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:432
+msgid "Query Settings"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:443
+msgid "List Settings"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:446
+msgid "Show list item numbers"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:455
+msgid "Show map"
+msgstr ""
+
+#. Translators: Help message for map behavior.
+#: src/blocks/curated-list/edit.js:458
+msgid "The map will display locations for up to %d items in the list, regardless of the current number of items shown."
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:471
+msgid "Show sort UI"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:477
+msgid "Featured Image Settings"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:480
+msgid "Show Featured Image"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:490
+msgid "Show Featured Image Caption"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:496
+msgid "Featured Image Position"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:500
+msgid "Top"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:501
+msgid "Left"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:502
+msgid "Right"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:511
+#: src/blocks/curated-list/edit.js:517
+msgid "Featured Image Size"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:542
+msgid "Minimum height"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:543
+msgid "Sets a minimum height for the block, using a percentage of the screen's current height."
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:555
+msgid "Post Control Settings"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:558
+msgid "Show Excerpt"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:565
+msgid "Type Scale"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:574
+msgid "Color Settings"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:580
+msgid "Text Color"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:585
+msgid "Background Color"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:589
+msgid "Meta Settings"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:592
+msgid "Show Author"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:599
+msgid "Show Category"
+msgstr ""
+
+#: src/blocks/curated-list/edit.js:606
+msgid "Show Tags"
+msgstr ""
+
+#: src/blocks/curated-list/index.js:26
+#: src/blocks/event-dates/index.js:24
+#: src/blocks/list-container/index.js:28
+#: src/blocks/price/index.js:24
+msgid "curated"
+msgstr ""
+
+#: src/blocks/curated-list/index.js:27
+#: src/blocks/event-dates/index.js:25
+#: src/blocks/list-container/index.js:29
+#: src/blocks/price/index.js:25
+#: src/blocks/self-serve-listings/index.js:24
+msgid "list"
+msgstr ""
+
+#: src/blocks/curated-list/index.js:28
+#: src/blocks/event-dates/index.js:26
+#: src/blocks/list-container/index.js:30
+#: src/blocks/listing/index.js:32
+#: src/blocks/price/index.js:26
+msgid "lists"
+msgstr ""
+
+#: src/blocks/curated-list/index.js:30
+#: src/blocks/event-dates/index.js:28
+#: src/blocks/list-container/index.js:32
+#: src/blocks/listing/index.js:34
+#: src/blocks/price/index.js:28
+msgid "latest"
+msgstr ""
+
+#: src/blocks/event-dates/edit.js:33
+msgid "Show Times"
+msgstr ""
+
+#. Translators: End date/time help message.
+#: src/blocks/event-dates/edit.js:43
+msgid "Show End %s"
+msgstr ""
+
+#: src/blocks/event-dates/edit.js:44
+#: src/blocks/event-dates/edit.js:64
+#: src/blocks/event-dates/edit.js:102
+msgid "Time"
+msgstr ""
+
+#: src/blocks/event-dates/edit.js:44
+#: src/blocks/event-dates/edit.js:64
+#: src/blocks/event-dates/edit.js:102
+msgid "Date"
+msgstr ""
+
+#. Translators: Help message for Event start date/time.
+#: src/blocks/event-dates/edit.js:62
+msgid "Event %1$s %2$s"
+msgstr ""
+
+#: src/blocks/event-dates/edit.js:63
+msgid "Start"
+msgstr ""
+
+#: src/blocks/event-dates/edit.js:81
+#: src/blocks/event-dates/edit.js:119
+msgid "Event end must be after event start."
+msgstr ""
+
+#: src/blocks/event-dates/edit.js:92
+#: src/blocks/event-dates/edit.js:130
+#: src/editor/featured-listings/index.js:181
+msgid "Reset"
+msgstr ""
+
+#. Translators: Help message for Event end date/time.
+#: src/blocks/event-dates/edit.js:101
+msgid "Event End %s"
+msgstr ""
+
+#: src/blocks/event-dates/index.js:17
+msgid "Event Dates"
+msgstr ""
+
+#: src/blocks/list-container/edit.js:45
+msgid "Sort by"
+msgstr ""
+
+#: src/blocks/list-container/index.js:20
+msgid "Container"
+msgstr ""
+
+#: src/blocks/listing/edit.js:102
+msgid "Search for a "
+msgstr ""
+
+#: src/blocks/listing/edit.js:104
+msgid " listing to display."
+msgstr ""
+
+#: src/blocks/listing/edit.js:161
+msgid "Cancel"
+msgstr ""
+
+#: src/blocks/price/edit.js:51
+msgid "Select currency"
+msgstr ""
+
+#: src/blocks/price/edit.js:67
+msgid "Show decimals"
+msgstr ""
+
+#: src/blocks/price/edit.js:68
+msgid "If disabled, the price shown will be rounded to the nearest integer."
+msgstr ""
+
+#. Translators: Price currency help message.
+#: src/blocks/price/edit.js:88
+msgid "Price in %s"
+msgstr ""
+
+#: src/blocks/price/index.js:29
+msgid "price"
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:55
+msgid "both single listings and subscriptions"
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:57
+msgid "single listings only"
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:59
+msgid "subscription listings only"
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:69
+msgid "Purchase Types Allowed"
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:71
+msgid "Allow readers to purchase %s."
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:78
+msgid "Single listings and subscriptions"
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:82
+msgid "Single listings only"
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:86
+msgid "Subscriptions only"
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:95
+msgid "Choose which listing types users are allowed to purchase."
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:99
+msgid "Allowed Single Listing Types"
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:131
+msgid "You must allow at least one listing type for purchase."
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:180
+msgid "Description text for your single listing product…"
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:258
+msgid "Description text for your subscription product…"
+msgstr ""
+
+#: src/blocks/self-serve-listings/edit.js:304
+msgid "Button text…"
+msgstr ""
+
+#: src/blocks/self-serve-listings/index.js:17
+msgid "Listings: Self-Serve Form"
+msgstr ""
+
+#: src/blocks/self-serve-listings/index.js:26
+msgid "self"
+msgstr ""
+
+#: src/blocks/self-serve-listings/index.js:27
+msgid "serve"
+msgstr ""
+
+#: src/editor/featured-listings/index.js:66
+#: src/editor/featured-listings/index.js:76
+msgid "There was an error updating the feature priority for this post. Please try saving again."
+msgstr ""
+
+#: src/editor/featured-listings/index.js:104
+msgid "There was an error fetching the priority for this post. Please refresh the editor."
+msgstr ""
+
+#: src/editor/featured-listings/index.js:117
+msgid "Featured Listing Settings"
+msgstr ""
+
+#: src/editor/featured-listings/index.js:122
+msgid "Featured Listing"
+msgstr ""
+
+#. Translators: Feature status help message.
+#: src/editor/featured-listings/index.js:125
+msgid "This listing is %sfeatured."
+msgstr ""
+
+#: src/editor/featured-listings/index.js:128
+msgid "not "
+msgstr ""
+
+#: src/editor/featured-listings/index.js:139
+msgid "Priority Level"
+msgstr ""
+
+#: src/editor/featured-listings/index.js:140
+msgid "Relative importance of the featured item. Higher numbers mean higher priority."
+msgstr ""
+
+#: src/editor/sidebar/index.js:66
+#: src/editor/sidebar/index.js:79
+msgid "Hide"
+msgstr ""
+
+#: src/editor/sidebar/index.js:66
+#: src/editor/sidebar/index.js:79
+msgid "Show"
+msgstr ""


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a POT file to the Newspack Listings plugin.

See 1200550061930446-as-1204498431816519

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Confirm the plugin has a /languages/newspack-listings.pot file.
3. Bonus: install and activate the [Loco Translate](https://wordpress.org/plugins/loco-translate/) plugin, and navigate to WP Admin > Loco Translate > Plugins in the left sidebar, and confirm the Listings plugin is available and can be translated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
