### PR TITLE
feat: add internationalization to event dates

### DIFF
--- a/src/templates/event-dates.php
+++ b/src/templates/event-dates.php
@@ -50,11 +50,12 @@ call_user_func(
 			class="newspack-listings__event-date"
 			datetime="<?php echo esc_attr( $show_time ? $attributes['startDate'] : Utils\strip_time( $attributes['startDate'] ) ); ?>"
 		>
+
 			<?php echo esc_html( $the_start_date ); ?>
 
 			<?php if ( $show_time ) : ?>
 				<span class="newspack-listings__event-date-time">
-					<?php echo date_i18n( $time_format, strtotime( $start_date->format( $time_format ) ) ); ?>
+					<?php echo esc_html( date_i18n( $time_format, strtotime( $start_date->format( $time_format ) ) ) ); ?>
 				</span>
 			<?php endif; ?>
 		</time>
@@ -75,7 +76,7 @@ call_user_func(
 				?>
 				<?php if ( $show_time ) : ?>
 					<span class="newspack-listings__event-time">
-						<?php echo date_i18n( $time_format, strtotime( $end_date->format( $time_format ) ) ); ?>
+						<?php echo esc_html( date_i18n( $time_format, strtotime( $end_date->format( $time_format ) ) ) ); ?>
 					</span>
 				<?php endif; ?>
 			</time>

--- a/src/templates/event-dates.php
+++ b/src/templates/event-dates.php
@@ -38,11 +38,11 @@ call_user_func(
 			}
 		}
 
-		$the_start_date = $start_date->format( $start_date_format );
+		$the_start_date = date_i18n( $start_date_format, strtotime( $start_date->format( $start_date_format ) ) );
 		$the_end_date   = '';
 
 		if ( ! empty( $end_date ) ) {
-			$the_end_date = $end_date->format( $end_date_format );
+			$the_end_date = date_i18n( $end_date_format, strtotime( $end_date->format( $end_date_format ) ) );
 		}
 		?>
 	<div class="newspack-listings__event-dates">
@@ -54,7 +54,7 @@ call_user_func(
 
 			<?php if ( $show_time ) : ?>
 				<span class="newspack-listings__event-date-time">
-					<?php echo esc_html( $start_date->format( $time_format ) ); ?>
+					<?php echo date_i18n( $time_format, strtotime( $start_date->format( $time_format ) ) ); ?>
 				</span>
 			<?php endif; ?>
 		</time>
@@ -75,7 +75,7 @@ call_user_func(
 				?>
 				<?php if ( $show_time ) : ?>
 					<span class="newspack-listings__event-time">
-						<?php echo esc_html( $end_date->format( $time_format ) ); ?>
+						<?php echo date_i18n( $time_format, strtotime( $end_date->format( $time_format ) ) ); ?>
 					</span>
 				<?php endif; ?>
 			</time>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds `date_i18n()` to the event listing dates, so they'll update when the site changes languages.

See 1200550061930446-as-1204498431816519

### How to test the changes in this Pull Request:

1. Apply the PR. 
2. Create a few event listings with different formats: just one date and a start and end date, and show or hide the times.
3. Confirm that the dates look as expected on the front-end.
4. Change the site's language under WP Admin > Settings > General.
5. Confirm that the date now picks up your site's new language.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
