### PR TITLE
feat(ia-epic): Adjustments to Menu for Information Architecture UI

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -95,6 +95,8 @@ final class Core {
 
 	/**
 	 * Add options page.
+	 * 
+	 * Note: with Newspack Plugin active and Information Architecture UI (2024): this callback is replaced.
 	 */
 	public static function add_plugin_page() {
 		// Top-level menu item.
@@ -108,6 +110,8 @@ final class Core {
 			35
 		);
 
+		// @ todo: possibly remove category and tags since these just redirect to Posts categories/tags.
+		
 		// Custom taxonomy menu links.
 		add_submenu_page(
 			'newspack-listings',
@@ -192,25 +196,7 @@ final class Core {
 				'rewrite'  => [ 'slug' => $prefix . $settings['newspack_listings_event_slug'] ],
 				'template' => [ [ 'newspack-listings/event-dates' ] ],
 			],
-			'generic'     => [
-				'labels'  => [
-					'name'               => _x( 'Generic Listings', 'post type general name', 'newspack-listings' ),
-					'singular_name'      => _x( 'Generic Listing', 'post type singular name', 'newspack-listings' ),
-					'menu_name'          => _x( 'Generic Listings', 'admin menu', 'newspack-listings' ),
-					'name_admin_bar'     => _x( 'Generic Listing', 'add new on admin bar', 'newspack-listings' ),
-					'add_new'            => _x( 'Add New', 'popup', 'newspack-listings' ),
-					'add_new_item'       => __( 'Add New Generic Listing', 'newspack-listings' ),
-					'new_item'           => __( 'New Generic Listing', 'newspack-listings' ),
-					'edit_item'          => __( 'Edit Generic Listing', 'newspack-listings' ),
-					'view_item'          => __( 'View Generic Listing', 'newspack-listings' ),
-					'all_items'          => __( 'Generic Listings', 'newspack-listings' ),
-					'search_items'       => __( 'Search Generic Listings', 'newspack-listings' ),
-					'parent_item_colon'  => __( 'Parent Generic Listing:', 'newspack-listings' ),
-					'not_found'          => __( 'No generic listings found.', 'newspack-listings' ),
-					'not_found_in_trash' => __( 'No generic listings found in Trash.', 'newspack-listings' ),
-				],
-				'rewrite' => [ 'slug' => $prefix . $settings['newspack_listings_generic_slug'] ],
-			],
+			// Move Marketplace above Generic here so that admin submenu will show Marketplace above Generic.
 			'marketplace' => [
 				'labels'  => [
 					'name'               => _x( 'Marketplace', 'post type general name', 'newspack-listings' ),
@@ -229,6 +215,25 @@ final class Core {
 					'not_found_in_trash' => __( 'No Marketplace listings found in Trash.', 'newspack-listings' ),
 				],
 				'rewrite' => [ 'slug' => $prefix . $settings['newspack_listings_marketplace_slug'] ],
+			],
+			'generic'     => [
+				'labels'  => [
+					'name'               => _x( 'Generic Listings', 'post type general name', 'newspack-listings' ),
+					'singular_name'      => _x( 'Generic Listing', 'post type singular name', 'newspack-listings' ),
+					'menu_name'          => _x( 'Generic Listings', 'admin menu', 'newspack-listings' ),
+					'name_admin_bar'     => _x( 'Generic Listing', 'add new on admin bar', 'newspack-listings' ),
+					'add_new'            => _x( 'Add New', 'popup', 'newspack-listings' ),
+					'add_new_item'       => __( 'Add New Generic Listing', 'newspack-listings' ),
+					'new_item'           => __( 'New Generic Listing', 'newspack-listings' ),
+					'edit_item'          => __( 'Edit Generic Listing', 'newspack-listings' ),
+					'view_item'          => __( 'View Generic Listing', 'newspack-listings' ),
+					'all_items'          => __( 'Generic Listings', 'newspack-listings' ),
+					'search_items'       => __( 'Search Generic Listings', 'newspack-listings' ),
+					'parent_item_colon'  => __( 'Parent Generic Listing:', 'newspack-listings' ),
+					'not_found'          => __( 'No generic listings found.', 'newspack-listings' ),
+					'not_found_in_trash' => __( 'No generic listings found in Trash.', 'newspack-listings' ),
+				],
+				'rewrite' => [ 'slug' => $prefix . $settings['newspack_listings_generic_slug'] ],
 			],
 			'place'       => [
 				'labels'  => [

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -95,7 +95,7 @@ final class Core {
 
 	/**
 	 * Add options page.
-	 * 
+	 *
 	 * Note: with Newspack Plugin active and Information Architecture UI (2024): this callback is replaced.
 	 */
 	public static function add_plugin_page() {
@@ -108,24 +108,6 @@ final class Core {
 			'',
 			'data:image/svg+xml;base64,PHN2ZyBmaWxsPSIjZmZmIiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJtNS41IDcuNWgydjJoLTJ6bTIgNGgtMnYyaDJ6bTEtNGg3djJoLTd6bTcgNGgtN3YyaDd6Ii8+PHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtNC42MjUgM2MtLjg5NyAwLTEuNjI1LjcyOC0xLjYyNSAxLjYyNXYxMS43NWMwIC44OTguNzI4IDEuNjI1IDEuNjI1IDEuNjI1aDExLjc1Yy44OTggMCAxLjYyNS0uNzI3IDEuNjI1LTEuNjI1di0xMS43NWMwLS44OTctLjcyNy0xLjYyNS0xLjYyNS0xLjYyNXptMTEuNzUgMS41aC0xMS43NWEuMTI1LjEyNSAwIDAgMCAtLjEyNS4xMjV2MTEuNzVjMCAuMDY5LjA1Ni4xMjUuMTI1LjEyNWgxMS43NWEuMTI1LjEyNSAwIDAgMCAuMTI1LS4xMjV2LTExLjc1YS4xMjUuMTI1IDAgMCAwIC0uMTI1LS4xMjV6IiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz48cGF0aCBkPSJtMjEuNzUgOGgtMS41djExYzAgLjY5LS41NiAxLjI1LTEuMjQ5IDEuMjVoLTEzLjAwMXYxLjVoMTMuMDAxYTIuNzQ5IDIuNzQ5IDAgMCAwIDIuNzQ5LTIuNzV6Ii8+PC9zdmc+Cg==',
 			35
-		);
-
-		// @ todo: possibly remove category and tags since these just redirect to Posts categories/tags.
-		
-		// Custom taxonomy menu links.
-		add_submenu_page(
-			'newspack-listings',
-			__( 'Newspack Listings: Categories', 'newspack-listings' ),
-			__( 'Categories', 'newspack-listings' ),
-			'manage_categories',
-			'edit-tags.php?taxonomy=category'
-		);
-		add_submenu_page(
-			'newspack-listings',
-			__( 'Newspack Listings: Tags', 'newspack-listings' ),
-			__( 'Tags', 'newspack-listings' ),
-			'manage_categories',
-			'edit-tags.php?taxonomy=post_tag'
 		);
 
 		// Settings menu link.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This code helps to complete Asana Task: "Newspack Information Architecture > IA Listings".  

See the primary PR here: https://github.com/Automattic/newspack-plugin/pull/3483

The code in this PR does 3 things:

1) It adds a helpful note above a callback function to alert future developers that the callback function might be removed via `remove_action` by the "parent" Newspack Plugin.  This could be helpful to know if a developer isn't seeing the correct output from the callback they expect.

2) It adds a "todo" that recommends we remove the Category and Tag links since they just link to the normal Posts categories and tags anyway.  This isn't needed in the main PR above, but in an effort to possibly "clean up" the plugin a bit, since it's getting cleaned up via the Information Architecture (IA) project anyway :-)

3) The final change, is the one that I highly recommend we do.  It will make the code in the main PR above easier.  The change here is to move "Marketplace Listings" above "Generic Listings".  In the IA project it was deemed that Marketplace should go above Generic.  So my recommendation is to do a little "clean up" in the Listings plugin now and move Marketplace above Generic :-) 

Screenshot:

![listings-plugin-recommendations](https://github.com/user-attachments/assets/6d2bb5f4-82fd-45ad-88a3-cf501fa854c9)


### How to test the changes in this Pull Request:

1. Pull this branch.
2. View the menu in wp-admin.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
