### PR TITLE
feat: update to new brand

### DIFF
--- a/src/assets/shared/variables.scss
+++ b/src/assets/shared/variables.scss
@@ -2,7 +2,7 @@
 :root {
 	--newspack-listings--background: #fff;
 	--newspack-listings--background-screen: #f1f1f1;
-	--newspack-listings--primary: #36f;
+	--newspack-listings--primary: #003da5;
 	--newspack-listings--secondary: #555;
 	--newspack-listings--grey-dark: #1e1e1e;
 	--newspack-listings--grey-medium: #757575;

--- a/src/blocks/curated-list/index.js
+++ b/src/blocks/curated-list/index.js
@@ -19,7 +19,7 @@ export const registerCuratedListBlock = () => {
 		title: __( 'Curated List', 'newspack-listings' ),
 		icon: {
 			src: <List />,
-			foreground: '#36f',
+			foreground: '#003da5',
 		},
 		category,
 		keywords: [

--- a/src/blocks/event-dates/index.js
+++ b/src/blocks/event-dates/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
-import { Icon, calendar } from '@wordpress/icons';
+import { calendar } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -16,8 +16,8 @@ export const registerEventDatesBlock = () => {
 	registerBlockType( name, {
 		title: __( 'Event Dates', 'newspack-listings' ),
 		icon: {
-			src: <Icon icon={ calendar } />,
-			foreground: '#36f',
+			src: calendar,
+			foreground: '#003da5',
 		},
 		category,
 		keywords: [

--- a/src/blocks/list-container/index.js
+++ b/src/blocks/list-container/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
-import { Icon, group } from '@wordpress/icons';
+import { group } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -19,8 +19,8 @@ export const registerListContainerBlock = () => {
 	registerBlockType( 'newspack-listings/list-container', {
 		title: __( 'Container', 'newspack-listings' ),
 		icon: {
-			src: <Icon icon={ group } />,
-			foreground: '#36f',
+			src: group,
+			foreground: '#003da5',
 		},
 		category: 'newspack',
 		parent: [ 'newspack-listings/curated-list' ],

--- a/src/blocks/listing/index.js
+++ b/src/blocks/listing/index.js
@@ -24,7 +24,7 @@ export const registerListingBlock = () => {
 				title: listingType.charAt( 0 ).toUpperCase() + listingType.slice( 1 ),
 				icon: {
 					src: getIcon( listingType ),
-					foreground: '#36f',
+					foreground: '#003da5',
 				},
 				category,
 				parent: [ 'newspack-listings/list-container' ],

--- a/src/blocks/price/index.js
+++ b/src/blocks/price/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
-import { Icon, currencyDollar } from '@wordpress/icons';
+import { currencyDollar } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -16,8 +16,8 @@ export const registerPriceBlock = () => {
 	registerBlockType( name, {
 		title: __( 'Price', 'newspack-listings' ),
 		icon: {
-			src: <Icon icon={ currencyDollar } />,
-			foreground: '#36f',
+			src: currencyDollar,
+			foreground: '#003da5',
 		},
 		category,
 		keywords: [

--- a/src/blocks/self-serve-listings/index.js
+++ b/src/blocks/self-serve-listings/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
-import { Icon, edit } from '@wordpress/icons';
+import { edit } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -16,8 +16,8 @@ export const registerSelfServeListingsBlock = () => {
 	registerBlockType( name, {
 		title: __( 'Listings: Self-Serve Form', 'newspack-listings' ),
 		icon: {
-			src: <Icon icon={ edit } />,
-			foreground: '#36f',
+			src: edit,
+			foreground: '#003da5',
 		},
 		category,
 		keywords: [

--- a/src/svg/newspack-logo.js
+++ b/src/svg/newspack-logo.js
@@ -4,14 +4,14 @@
 import { Path, SVG } from '@wordpress/components';
 
 const NewspackLogo = ( { size = 24 } ) => (
-	<SVG className="newspack-logo" width={ size } height={ size } viewBox="0 0 32 32">
+	<SVG className="newspack-logo" width={ size } height={ size } viewBox="0 0 24 24">
 		<Path
-			d="M16 32c8.836 0 16-7.164 16-16S24.836 0 16 0 0 7.164 0 16s7.163 16 16 16z"
-			fill="#36F"
+			fill="#003da5"
+			d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Z"
 		/>
 		<Path
-			d="M22.988 16.622h-1.72l-1.103-1.124h2.823v1.124zm0-3.31H18.02l-1.102-1.124h6.071v1.124zm0-3.31h-8.217l-1.103-1.125h9.32v1.125zm0 13.12L9.012 8.878v4.749l.069.071h-.07v9.426h3.451v-5.98l5.867 5.98h4.66z"
 			fill="#fff"
+			d="M16.546 13.97v-1.364h-1.364l1.364 1.364ZM13.97 11.394h2.575V10.03h-3.939l1.364 1.364ZM11.394 8.818h5.152V7.455H10.03l1.364 1.363ZM7.455 7.455l9.09 9.09H13.97l-4.697-4.697v4.697H7.455v-9.09Z"
 		/>
 	</SVG>
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the blocks's icon colour to be in line with the new brand.

### How to test the changes in this Pull Request:

1. Check the blocks if they have the new blue

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
