### PR TITLE
feat: add AI agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Shared conventions (Docker, `n` script, coding standards, git rules) are in `../
 
 - **Front-end scripts are auto-discovered.** Any `.js` file in `src/assets/front-end/` automatically becomes a webpack entry point (`webpack.config.js` uses `fs.readdirSync()`).
 
-- **All blocks are server-side rendered** via `view.php` templates. Most `save` function returns `null`. The exceptions are `curated-list` and `list-container`, which return `<InnerBlocks.Content />` to persist inner block content.
+- **All blocks are server-side rendered** via `view.php` templates. Most `save` functions return `null`. The exceptions are `curated-list` and `list-container`, which return `<InnerBlocks.Content />` to persist inner block content.
 
 - **WooCommerce integration is conditional.** `class-products.php` and subclasses in `includes/products/` only activate when WooCommerce, WooCommerce Subscriptions, and the `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` constant are all present. Self-serve listings won't work without these conditions, with no visible error.
 
@@ -26,7 +26,7 @@ Shared conventions (Docker, `n` script, coding standards, git rules) are in `../
 
 - **Mixed React patterns.** Most blocks use `withSelect`/`withDispatch` HOCs. Only `event-dates` uses modern hooks. Match the existing pattern when modifying a block; prefer hooks for new code.
 
-- **NEWSPACK_LISTINGS_PLUGIN_FILE is misleadingly named.** It holds the directory path (from `plugin_dir_path()`), not a file path. It always ends with a trailing slash. The actual main plugin file path is `NEWSPACK_LISTINGS_FILE` (set to `__FILE__`). Usage of `require_once` paths using `NEWSPACK_LISTINGS_PLUGIN_FILE` are also inconsistent. For example, `newspack-listings.php` uses a leading slash (`NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/...'`) while `class-products.php` omits it (`NEWSPACK_LISTINGS_PLUGIN_FILE . 'includes/...'). Both resolve correctly because `plugin_dir_path()` returns a trailing slash.
+- **NEWSPACK_LISTINGS_PLUGIN_FILE is misleadingly named.** It holds the directory path (from `plugin_dir_path()`), not a file path. It always ends with a trailing slash. The actual main plugin file path is `NEWSPACK_LISTINGS_FILE` (set to `__FILE__`). Usage of `require_once` paths using `NEWSPACK_LISTINGS_PLUGIN_FILE` are also inconsistent. For example, `newspack-listings.php` uses a leading slash (`NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/...'`) while `class-products.php` omits it (`NEWSPACK_LISTINGS_PLUGIN_FILE . 'includes/...'`). Both resolve correctly because `plugin_dir_path()` returns a trailing slash.
 
 
 ## Dominant pattern: adding a PHP class

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,80 +1,51 @@
-# Newspack Listings: Agent Instructions
+# Newspack Listings agent guide
 
-This file covers what is specific to `newspack-listings`. Shared conventions (Docker commands, `n` script, coding standards, git rules, etc.) are in the root `newspack-workspace/AGENTS.md`.
-
-## Core Architecture
-
-### Custom Post Types
-
-All four listing CPTs are defined in [`Core::NEWSPACK_LISTINGS_POST_TYPES`](includes/class-core.php#L27) ([`includes/class-core.php:27`](includes/class-core.php#L27)):
-
-| Key           | Slug                   | Permalink    |
-|---------------|------------------------|--------------|
-| `event`       | `newspack_lst_event`   | `/events/`   |
-| `generic`     | `newspack_lst_generic` | `/items/`    |
-| `marketplace` | `newspack_lst_mktplce` | `/marketplace/` |
-| `place`       | `newspack_lst_place`   | `/places/`   |
-
-Use [`Core::is_listing( $post_type )`](includes/class-core.php#L131) to check whether a post type is a listing.
-
-### Meta Syncing from Blocks
-
-Block attributes are synced to post meta on every `save_post` via [`Core::sync_post_meta()`](includes/class-core.php#L641) ([`includes/class-core.php:641`](includes/class-core.php#L641)). The flow:
-
-1. `save_post` fires for a listing CPT.
-2. Post content is parsed into blocks via `parse_blocks()`.
-3. Each meta field registered in [`Core::get_meta_fields()`](includes/class-core.php#L270) that has a `source` key is matched to a block type + attribute.
-4. [`Utils\get_data_from_blocks()`](includes/utils.php#L121) ([`includes/utils.php:121`](includes/utils.php#L121)) extracts the attribute value from the matching block.
-5. Post meta is updated (or deleted if the block is removed).
-
-See [`class-core.php:428`](includes/class-core.php#L428) for the meta field definition format.
-
-### Featured Listings
-
-Featured priority is stored in a custom DB table (`wp_newspack_listings_priority`) instead of post meta for query performance. Defined in [`includes/class-featured.php`](includes/class-featured.php):
-
-- **Table columns**: `post_id` (PK), `feature_priority` (0 = not featured, 1-9 = priority)
-- **Sorting**: `posts_clauses` filter joins the table at query time ([`Featured::sort_featured_listings`](includes/class-featured.php#L326))
-- **Meta keys**: `newspack_listings_featured`, `newspack_listings_featured_expires`
-
-### Blocks
-
-Blocks are registered based on context ([`src/editor/index.js`](src/editor/index.js)). The [`isListing()`](src/editor/utils.js#L17) utility checks `window.newspack_listings_data.post_type` against registered listing CPTs. Blocks are registered based on whether the current editor is for a listing CPT or not.
-
-Discover all blocks via `src/blocks/*/block.json`.
-
-### Template Pattern
-
-Server-side templates use closures for variable isolation (`call_user_func` wrapping `$data`). Templates are loaded via [`Utils\template_include( 'listing', $data )`](includes/utils.php#L41) ([`includes/utils.php:41`](includes/utils.php#L41)), which uses output buffering to return rendered HTML. See [`src/templates/listing.php`](src/templates/listing.php#L12) for the pattern.
+Shared conventions (Docker, `n` script, coding standards, git rules) are in `../../AGENTS.md`.
 
 ## Gotchas
 
-1. **Meta syncing is automatic** - Changing a block's attribute name or block name breaks the `source` mapping in [`Core::get_meta_fields()`](includes/class-core.php#L270). Always update both together.
-2. **Featured priority uses a custom table**, not post meta. Direct `get_post_meta()` calls won't return priority values. Use [`Featured::get_priority()`](includes/class-featured.php#L229).
-3. **`isListing()` controls block visibility** - Editor-only blocks won't appear outside listing CPTs. If a block should appear everywhere, register it in the non-listing branch of [`src/editor/index.js`](src/editor/index.js).
-4. **Block `save` returns `null`** - All blocks use server-side rendering via `view.php` templates. Don't add JSX to `save` functions.
-5. **Template variable isolation** - Templates wrap in `call_user_func` closures. Access data only through the `$data` parameter, not global variables.
-6. **CPT slugs are abbreviated** (`newspack_lst_mktplce`, not `newspack_lst_marketplace`). Always reference `Core::NEWSPACK_LISTINGS_POST_TYPES` instead of hardcoding slugs.
-7. **All major classes use the singleton pattern** - Access instances via `ClassName::instance()`, not `new ClassName()`.
-8. **WooCommerce integration is optional** - `class-products.php` only loads if WooCommerce is active. Don't assume its classes exist.
-9. **No JavaScript tests** in this repo. Only PHPUnit tests in `tests/`.
+- **No PHP autoloader.** All classes use manual `require_once`. Adding a new class requires a corresponding `require_once` in `newspack-listings.php` (or `class-products.php` for product subclasses). Forgetting this fails silently until the class is instantiated.
 
-## Recipes
+- **CPT slug is abbreviated.** Marketplace post type is `newspack_lst_mktplce`, not `newspack_lst_marketplace`. Always use `Core::NEWSPACK_LISTINGS_POST_TYPES` instead of hardcoding slugs.
 
-### Add a New Synced Meta Field
+- **Featured priority uses a custom DB table** (`wp_newspack_listings_priority`), not post meta. `get_post_meta()` won't return priority values. Use `Featured::get_priority()`. Schema changes require bumping `Featured::TABLE_VERSION`.
 
-**Goal**: Store a block attribute as post meta so it's queryable.
+- **Block attribute-to-meta syncing.** Block attributes auto-sync to post meta via `Core::sync_post_meta()` on `save_post`. The mapping lives in `Core::get_meta_fields()` using a `source` key. Renaming a block attribute or block name without updating the source mapping silently breaks syncing.
 
-1. **Register the meta field** in [`Core::get_meta_fields()`](includes/class-core.php#L270). Add an entry following the existing format (see [`class-core.php:428`](includes/class-core.php#L428) for an example).
-2. **Add the attribute** to the block's `block.json` ([`src/blocks/event-dates/block.json`](src/blocks/event-dates/block.json)).
-3. **Use the attribute** in the block's `edit.js` component and `view.php` template.
-4. **Test**: Save a listing, then verify with `get_post_meta( $post_id, 'newspack_listings_my_field', true )`.
+- **"newspack-listings/listing" is not a real block.** The listing block dynamically registers per-CPT variants (`newspack-listings/event`, `newspack-listings/generic`, etc.) at runtime from `window.newspack_listings_data.post_types`. See `src/blocks/listing/index.js`.
 
-The `save_post` hook in [`Core::sync_post_meta()`](includes/class-core.php#L641) handles the rest automatically.
+- **All block JS compiles into `dist/editor.js`.** Block directories under `src/blocks/` have `block.json` but no individual JS bundles in `dist/`.
 
-### Add a New Block
+- **Front-end scripts are auto-discovered.** Any `.js` file in `src/assets/front-end/` automatically becomes a webpack entry point (`webpack.config.js` uses `fs.readdirSync()`).
 
-1. **Create the block directory** under `src/blocks/my-block/` with `block.json`, `index.js`, `edit.js`, and `view.php`.
-2. **Register in the editor** ([`src/editor/index.js`](src/editor/index.js)) in the appropriate branch (isListing or not).
-3. **Register server-side rendering** in [`includes/class-blocks.php`](includes/class-blocks.php) if the block needs PHP rendering.
-4. **Follow existing patterns**: `save: () => null`, functional React components, `InspectorControls` for sidebar settings.
+- **All blocks are server-side rendered.** Every `save` function returns `null`. Rendering is in `view.php` templates.
+
+- **WooCommerce integration is conditional.** `class-products.php` and subclasses in `includes/products/` only activate when WooCommerce is present. Self-serve listings won't work without it, with no visible error.
+
+- **No JavaScript tests.** `npm test` is a no-op. Only PHPUnit tests exist.
+
+- **Mixed React patterns.** Most blocks use `withSelect`/`withDispatch` HOCs. Only `event-dates` uses modern hooks. Match the existing pattern when modifying a block; prefer hooks for new code.
+
+## Dominant pattern: adding a PHP class
+
+```php
+// 1. Create includes/class-my-feature.php
+class My_Feature {
+	private static $instance;
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+	private function __construct() {
+		// Register hooks here.
+	}
+}
+My_Feature::instance(); // Self-instantiate at end of file.
+```
+
+```php
+// 2. Add require_once in newspack-listings.php (no autoloader).
+require_once NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/class-my-feature.php';
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# Newspack Listings: Agent Instructions
+
+This file covers what is specific to `newspack-listings`. Shared conventions (Docker commands, `n` script, coding standards, git rules, etc.) are in the root `newspack-workspace/AGENTS.md`.
+
+## Core Architecture
+
+### Custom Post Types
+
+All four listing CPTs are defined in [`Core::NEWSPACK_LISTINGS_POST_TYPES`](includes/class-core.php#L27) ([`includes/class-core.php:27`](includes/class-core.php#L27)):
+
+| Key           | Slug                   | Permalink    |
+|---------------|------------------------|--------------|
+| `event`       | `newspack_lst_event`   | `/events/`   |
+| `generic`     | `newspack_lst_generic` | `/items/`    |
+| `marketplace` | `newspack_lst_mktplce` | `/marketplace/` |
+| `place`       | `newspack_lst_place`   | `/places/`   |
+
+Use [`Core::is_listing( $post_type )`](includes/class-core.php#L131) to check whether a post type is a listing.
+
+### Meta Syncing from Blocks
+
+Block attributes are synced to post meta on every `save_post` via [`Core::sync_post_meta()`](includes/class-core.php#L641) ([`includes/class-core.php:641`](includes/class-core.php#L641)). The flow:
+
+1. `save_post` fires for a listing CPT.
+2. Post content is parsed into blocks via `parse_blocks()`.
+3. Each meta field registered in [`Core::get_meta_fields()`](includes/class-core.php#L270) that has a `source` key is matched to a block type + attribute.
+4. [`Utils\get_data_from_blocks()`](includes/utils.php#L121) ([`includes/utils.php:121`](includes/utils.php#L121)) extracts the attribute value from the matching block.
+5. Post meta is updated (or deleted if the block is removed).
+
+See [`class-core.php:428`](includes/class-core.php#L428) for the meta field definition format.
+
+### Featured Listings
+
+Featured priority is stored in a custom DB table (`wp_newspack_listings_priority`) instead of post meta for query performance. Defined in [`includes/class-featured.php`](includes/class-featured.php):
+
+- **Table columns**: `post_id` (PK), `feature_priority` (0 = not featured, 1-9 = priority)
+- **Sorting**: `posts_clauses` filter joins the table at query time ([`Featured::sort_featured_listings`](includes/class-featured.php#L326))
+- **Meta keys**: `newspack_listings_featured`, `newspack_listings_featured_expires`
+
+### Block Hierarchy
+
+Blocks split into two groups based on context ([`src/editor/index.js`](src/editor/index.js)). The [`isListing()`](src/editor/utils.js#L17) utility checks `window.newspack_listings_data.post_type` against registered listing CPTs:
+
+- **Editor-only blocks** (registered when `isListing()` is true): only available when editing a listing CPT.
+- **Frontend blocks** (registered when `isListing()` is false): available in regular posts/pages.
+
+Discover all blocks via `src/blocks/*/block.json`.
+
+### Template Pattern
+
+Server-side templates use closures for variable isolation (`call_user_func` wrapping `$data`). Templates are loaded via [`Utils\template_include( 'listing', $data )`](includes/utils.php#L41) ([`includes/utils.php:41`](includes/utils.php#L41)), which uses output buffering to return rendered HTML. See [`src/templates/listing.php`](src/templates/listing.php#L12) for the pattern.
+
+## Gotchas
+
+1. **Meta syncing is automatic** - Changing a block's attribute name or block name breaks the `source` mapping in [`Core::get_meta_fields()`](includes/class-core.php#L270). Always update both together.
+2. **Featured priority uses a custom table**, not post meta. Direct `get_post_meta()` calls won't return priority values. Use [`Featured::get_priority()`](includes/class-featured.php#L229).
+3. **`isListing()` controls block visibility** - Editor-only blocks won't appear outside listing CPTs. If a block should appear everywhere, register it in the non-listing branch of [`src/editor/index.js`](src/editor/index.js).
+4. **Block `save` returns `null`** - All blocks use server-side rendering via `view.php` templates. Don't add JSX to `save` functions.
+5. **Template variable isolation** - Templates wrap in `call_user_func` closures. Access data only through the `$data` parameter, not global variables.
+6. **CPT slugs are abbreviated** (`newspack_lst_mktplce`, not `newspack_lst_marketplace`). Always reference `Core::NEWSPACK_LISTINGS_POST_TYPES` instead of hardcoding slugs.
+7. **All major classes use the singleton pattern** - Access instances via `ClassName::instance()`, not `new ClassName()`.
+8. **WooCommerce integration is optional** - `class-products.php` only loads if WooCommerce is active. Don't assume its classes exist.
+9. **No JavaScript tests** in this repo. Only PHPUnit tests in `tests/`.
+
+## Recipes
+
+### Add a New Synced Meta Field
+
+**Goal**: Store a block attribute as post meta so it's queryable.
+
+1. **Register the meta field** in [`Core::get_meta_fields()`](includes/class-core.php#L270). Add an entry following the existing format (see [`class-core.php:428`](includes/class-core.php#L428) for an example).
+2. **Add the attribute** to the block's `block.json` ([`src/blocks/event-dates/block.json`](src/blocks/event-dates/block.json)).
+3. **Use the attribute** in the block's `edit.js` component and `view.php` template.
+4. **Test**: Save a listing, then verify with `get_post_meta( $post_id, 'newspack_listings_my_field', true )`.
+
+The `save_post` hook in [`Core::sync_post_meta()`](includes/class-core.php#L641) handles the rest automatically.
+
+### Add a New Block
+
+1. **Create the block directory** under `src/blocks/my-block/` with `block.json`, `index.js`, `edit.js`, and `view.php`.
+2. **Register in the editor** ([`src/editor/index.js`](src/editor/index.js)) in the appropriate branch (isListing or not).
+3. **Register server-side rendering** in [`includes/class-blocks.php`](includes/class-blocks.php) if the block needs PHP rendering.
+4. **Follow existing patterns**: `save: () => null`, functional React components, `InspectorControls` for sidebar settings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,12 +37,9 @@ Featured priority is stored in a custom DB table (`wp_newspack_listings_priority
 - **Sorting**: `posts_clauses` filter joins the table at query time ([`Featured::sort_featured_listings`](includes/class-featured.php#L326))
 - **Meta keys**: `newspack_listings_featured`, `newspack_listings_featured_expires`
 
-### Block Hierarchy
+### Blocks
 
-Blocks split into two groups based on context ([`src/editor/index.js`](src/editor/index.js)). The [`isListing()`](src/editor/utils.js#L17) utility checks `window.newspack_listings_data.post_type` against registered listing CPTs:
-
-- **Editor-only blocks** (registered when `isListing()` is true): only available when editing a listing CPT.
-- **Frontend blocks** (registered when `isListing()` is false): available in regular posts/pages.
+Blocks are registered based on context ([`src/editor/index.js`](src/editor/index.js)). The [`isListing()`](src/editor/utils.js#L17) utility checks `window.newspack_listings_data.post_type` against registered listing CPTs. Blocks are registered based on whether the current editor is for a listing CPT or not.
 
 Discover all blocks via `src/blocks/*/block.json`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Shared conventions (Docker, `n` script, coding standards, git rules) are in `../
 
 ## Gotchas
 
-- **No PHP autoloader.** All classes use manual `require_once`. Adding a new class requires a corresponding `require_once` in `newspack-listings.php` (or `class-products.php` for product subclasses). Forgetting this fails silently until the class is instantiated.
+- **No autoloader for plugin classes.** Composer's autoloader exists but only handles dev tooling. All plugin classes use manual `require_once`. Adding a new class requires a corresponding `require_once` in `newspack-listings.php` (or `class-products.php` for product subclasses). Forgetting this fails silently until the class is instantiated.
 
 - **CPT slug is abbreviated.** Marketplace post type is `newspack_lst_mktplce`, not `newspack_lst_marketplace`. Always use `Core::NEWSPACK_LISTINGS_POST_TYPES` instead of hardcoding slugs.
 
@@ -18,13 +18,16 @@ Shared conventions (Docker, `n` script, coding standards, git rules) are in `../
 
 - **Front-end scripts are auto-discovered.** Any `.js` file in `src/assets/front-end/` automatically becomes a webpack entry point (`webpack.config.js` uses `fs.readdirSync()`).
 
-- **All blocks are server-side rendered.** Every `save` function returns `null`. Rendering is in `view.php` templates.
+- **All blocks are server-side rendered** via `view.php` templates. Most `save` function returns `null`. The exceptions are `curated-list` and `list-container`, which return `<InnerBlocks.Content />` to persist inner block content.
 
-- **WooCommerce integration is conditional.** `class-products.php` and subclasses in `includes/products/` only activate when WooCommerce is present. Self-serve listings won't work without it, with no visible error.
+- **WooCommerce integration is conditional.** `class-products.php` and subclasses in `includes/products/` only activate when WooCommerce, WooCommerce Subscriptions, and the `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` constant are all present. Self-serve listings won't work without these conditions, with no visible error.
 
 - **No JavaScript tests.** `npm test` is a no-op. Only PHPUnit tests exist.
 
 - **Mixed React patterns.** Most blocks use `withSelect`/`withDispatch` HOCs. Only `event-dates` uses modern hooks. Match the existing pattern when modifying a block; prefer hooks for new code.
+
+- **NEWSPACK_LISTINGS_PLUGIN_FILE is misleadingly named.** It holds the directory path (from `plugin_dir_path()`), not a file path. It always ends with a trailing slash. The actual main plugin file path is `NEWSPACK_LISTINGS_FILE` (set to `__FILE__`). Usage of `require_once` paths using `NEWSPACK_LISTINGS_PLUGIN_FILE` are also inconsistent. For example, `newspack-listings.php` uses a leading slash (`NEWSPACK_LISTINGS_PLUGIN_FILE . '/includes/...'`) while `class-products.php` omits it (`NEWSPACK_LISTINGS_PLUGIN_FILE . 'includes/...'). Both resolve correctly because `plugin_dir_path()` returns a trailing slash.
+
 
 ## Dominant pattern: adding a PHP class
 
@@ -44,6 +47,8 @@ class My_Feature {
 }
 My_Feature::instance(); // Self-instantiate at end of file.
 ```
+
+Note: The above singleton pattern is commonly used, but there are a few exceptions where classes are defined using a static `init()` method (i.e. `Settings`, `Products`) . All new classes should follow the singleton pattern for consistency, unless there's a specific reason to deviate.
 
 ```php
 // 2. Add require_once in newspack-listings.php (no autoloader).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Changes proposed
Add `AGENTS.md` and `CLAUDE.md` to provide AI coding agents with repo-specific guidance. 

The `CLAUDE.md` simply references `AGENTS.md`, matching the pattern used in the parent workspace. General topics (Docker, `n` script, coding standards, git rules) are not duplicated — the file links to the workspace-level `AGENTS.md` instead.

**Note**: See discussion in slack (p1771952317568379/1771870204.767739-slack-C015W6BES8J) for details on new `AGENTS.md` strategy.

## How to test
1. Review `AGENTS.md` for accuracy against the codebase.
2. Confirm `CLAUDE.md` contains only `@AGENTS.md`.