### PR TITLE
fix: update blocks for compatibility with iframe-based Post Editor

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -44,7 +44,7 @@ final class Blocks {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'manage_editor_assets' ] );
+		add_action( 'enqueue_block_assets', [ __CLASS__, 'manage_block_assets' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'custom_scripts' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'custom_styles' ] );
 		add_action( 'init', [ __CLASS__, 'manage_view_assets' ] );
@@ -53,7 +53,11 @@ final class Blocks {
 	/**
 	 * Enqueue editor assets.
 	 */
-	public static function manage_editor_assets() {
+	public static function manage_block_assets() {
+		if ( ! wp_should_load_block_editor_scripts_and_styles() ) {
+			return;
+		}
+
 		wp_enqueue_script(
 			'newspack-listings-editor',
 			NEWSPACK_LISTINGS_URL . 'dist/editor.js',
@@ -161,6 +165,7 @@ final class Blocks {
 				register_block_type(
 					$block_name,
 					[
+						'api_version'     => 3,
 						'render_callback' => function( $attributes, $content ) use ( $type ) {
 							Newspack_Blocks::enqueue_view_assets( $type );
 							return $content;

--- a/src/blocks/curated-list/block.json
+++ b/src/blocks/curated-list/block.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "newspack-listings/curated-list",
 	"category": "newspack",
 	"attributes": {

--- a/src/blocks/curated-list/edit.js
+++ b/src/blocks/curated-list/edit.js
@@ -9,6 +9,7 @@ import {
 	InnerBlocks,
 	InspectorControls,
 	PanelColorSettings,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import {
@@ -36,7 +37,11 @@ import { Icon, loop, postList } from '@wordpress/icons';
 import { Listing } from '../listing/listing';
 import { SidebarQueryControls } from '../../components';
 import { List } from '../../svg';
-import { getContrastRatio, getCuratedListClasses, useDidMount } from '../../editor/utils';
+import {
+	getContrastRatio,
+	getCuratedListClasses,
+	useDidMount,
+} from '../../editor/utils';
 
 /**
  * Debounced fetchPosts function outside of component scope.
@@ -51,10 +56,9 @@ let debouncedFetchPosts;
  */
 const MAX_EDITOR_ITEMS = 100;
 
-const CuratedListEditorComponent = ( {
+const CuratedListEditorComponent = ({
 	attributes,
 	canUseMapBlock,
-	className,
 	clientId,
 	innerBlocks,
 	insertBlocks,
@@ -64,10 +68,13 @@ const CuratedListEditorComponent = ( {
 	selectedBlock,
 	setAttributes,
 	updateBlockAttributes,
-} ) => {
-	const [ error, setError ] = useState( null );
-	const [ isFetching, setIsFetching ] = useState( false );
-	const [ locations, setLocations ] = useState( [] );
+}) => {
+	const [error, setError] = useState(null);
+	const [isFetching, setIsFetching] = useState(false);
+	const [locations, setLocations] = useState([]);
+	const blockProps = useBlockProps({
+		className: 'newspack-listings__curated-list-editor',
+	});
 	const {
 		showNumbers,
 		showMap,
@@ -92,10 +99,14 @@ const CuratedListEditorComponent = ( {
 		loadMoreText,
 	} = attributes;
 
-	const isEmpty = !! window.newspack_listings_data.no_listings || false;
-	const list = innerBlocks.find( innerBlock => innerBlock.name === 'newspack-listings/list-container' );
-	const hasMap = innerBlocks.find( innerBlock => innerBlock.name === 'jetpack/map' );
-	const classes = getCuratedListClasses( className, attributes );
+	const isEmpty = !!window.newspack_listings_data.no_listings || false;
+	const list = innerBlocks.find(
+		innerBlock => innerBlock.name === 'newspack-listings/list-container'
+	);
+	const hasMap = innerBlocks.find(
+		innerBlock => innerBlock.name === 'jetpack/map'
+	);
+	const classes = getCuratedListClasses(blockProps.className, attributes);
 	const initialRender = useDidMount();
 
 	/**
@@ -105,198 +116,211 @@ const CuratedListEditorComponent = ( {
 	 * @return {void}
 	 */
 	const fetchPosts = async query => {
-		if ( isFetching || ! queryMode ) {
+		if (isFetching || !queryMode) {
 			return;
 		}
 
-		setIsFetching( true );
+		setIsFetching(true);
 
 		try {
-			setError( null );
-			const posts = await apiFetch( {
-				path: addQueryArgs( '/newspack-listings/v1/listings', {
+			setError(null);
+			const posts = await apiFetch({
+				path: addQueryArgs('/newspack-listings/v1/listings', {
 					query: { maxItems: MAX_EDITOR_ITEMS, ...query }, // Get up to MAX_EDITOR_ITEMS listings in the editor so we can show all locations.
-					_fields: 'id,title,author,category,tags,excerpt,media,meta,type,sponsors,classes',
-				} ),
-			} );
-			setAttributes( { listingIds: posts.map( post => post.id ) } );
-			setAttributes( { queriedListings: posts } );
+					_fields:
+						'id,title,author,category,tags,excerpt,media,meta,type,sponsors,classes',
+				}),
+			});
+			setAttributes({ listingIds: posts.map(post => post.id) });
+			setAttributes({ queriedListings: posts });
 
-			if ( 0 === posts.length ) {
+			if (0 === posts.length) {
 				throw 'No posts matching query options. Try selecting different or less specific query options.';
 			}
-		} catch ( e ) {
-			setError( e );
+		} catch (e) {
+			setError(e);
 		}
 
-		setIsFetching( false );
+		setIsFetching(false);
 	};
 
 	/**
 	 * If changing query options, fetch listing posts that match the query.
 	 */
-	useEffect( () => {
-		if ( initialRender ) {
-			fetchPosts( queryOptions );
+	useEffect(() => {
+		if (initialRender) {
+			fetchPosts(queryOptions);
 		} else {
 			// Debounced version of fetchPosts to minimize consecutive executions.
-			clearTimeout( debouncedFetchPosts );
-			debouncedFetchPosts = setTimeout( () => {
-				fetchPosts( queryOptions );
-			}, 500 );
+			clearTimeout(debouncedFetchPosts);
+			debouncedFetchPosts = setTimeout(() => {
+				fetchPosts(queryOptions);
+			}, 500);
 		}
-	}, [ JSON.stringify( queryOptions ), queryMode ] );
+	}, [JSON.stringify(queryOptions), queryMode]);
 
 	/**
 	 * Set isSelected attribute so child blocks know selected state.
 	 */
-	useEffect( () => {
-		setAttributes( { isSelected } );
-	}, [ isSelected ] );
+	useEffect(() => {
+		setAttributes({ isSelected });
+	}, [isSelected]);
 
 	/**
 	 * Update locations in component state. This lets us keep the map block in sync with listing items.
 	 */
-	useEffect( () => {
-		if ( ! canUseMapBlock ) {
+	useEffect(() => {
+		if (!canUseMapBlock) {
 			return;
 		}
 
 		let newLocations = [];
 
 		// Only build locations array if we have any listings, and the Jetpack Maps block exists.
-		if ( queryMode ) {
-			newLocations = queriedListings.reduce( ( acc, queriedListing ) => {
-				if ( queriedListing.meta && queriedListing.meta.newspack_listings_locations ) {
-					queriedListing.meta.newspack_listings_locations.map( location => {
-						if ( isValidLocation( location ) ) {
-							acc.push( location );
-						}
+		if (queryMode) {
+			newLocations = queriedListings.reduce((acc, queriedListing) => {
+				if (
+					queriedListing.meta &&
+					queriedListing.meta.newspack_listings_locations
+				) {
+					queriedListing.meta.newspack_listings_locations.map(
+						location => {
+							if (isValidLocation(location)) {
+								acc.push(location);
+							}
 
-						return acc;
-					} );
+							return acc;
+						}
+					);
 				}
 
 				return acc;
-			}, [] );
+			}, []);
 		} else {
 			newLocations = list
-				? list.innerBlocks.reduce( ( acc, innerBlock ) => {
-						if ( innerBlock.attributes.locations && 0 < innerBlock.attributes.locations.length ) {
-							innerBlock.attributes.locations.map( location => {
-								if ( isValidLocation( location ) ) {
-									acc.push( location );
+				? list.innerBlocks.reduce((acc, innerBlock) => {
+						if (
+							innerBlock.attributes.locations &&
+							0 < innerBlock.attributes.locations.length
+						) {
+							innerBlock.attributes.locations.map(location => {
+								if (isValidLocation(location)) {
+									acc.push(location);
 								}
 
 								return acc;
-							} );
+							});
 						}
 						return acc;
-				  }, [] )
+					}, [])
 				: [];
 		}
 
-		setLocations( newLocations );
-	}, [ list, JSON.stringify( queriedListings ), queryMode ] );
+		setLocations(newLocations);
+	}, [list, JSON.stringify(queriedListings), queryMode]);
 
 	/**
 	 * Keep track of post IDs of all nested listings in specific listings mode.
 	 */
-	useEffect( () => {
-		if ( ! queryMode && list ) {
-			const newListingIds = list.innerBlocks.map( innerBlock => parseInt( innerBlock.attributes.listing ) );
+	useEffect(() => {
+		if (!queryMode && list) {
+			const newListingIds = list.innerBlocks.map(innerBlock =>
+				parseInt(innerBlock.attributes.listing)
+			);
 
-			setAttributes( { listingIds: newListingIds } );
+			setAttributes({ listingIds: newListingIds });
 		}
-	}, [ list ] );
+	}, [list]);
 
 	/**
 	 * Create, update, or remove map when showMap attribute or locations change.
 	 */
-	useEffect( () => {
+	useEffect(() => {
 		// Don't run on the initial render.
-		if ( initialRender ) {
+		if (initialRender) {
 			return;
 		}
 
 		// Don't bother if the Jetpack Maps block doesn't exist.
-		if ( ! canUseMapBlock ) {
+		if (!canUseMapBlock) {
 			return;
 		}
 
 		// If showMap toggle is enabled, update the existing map or create a new one.
-		if ( showMap && 0 < locations.length ) {
-			if ( hasMap ) {
+		if (showMap && 0 < locations.length) {
+			if (hasMap) {
 				// If we already have a map, update it.
-				updateBlockAttributes( hasMap.clientId, { points: locations } );
+				updateBlockAttributes(hasMap.clientId, { points: locations });
 			} else {
 				// Don't add a new map unless we have some locations to show.
-				if ( 0 === locations.length ) {
+				if (0 === locations.length) {
 					return;
 				}
 
 				// Create a new map at the top of the list.
-				const newBlock = createBlock( 'jetpack/map', {
+				const newBlock = createBlock('jetpack/map', {
 					points: locations,
-				} );
+				});
 
-				insertBlocks( [ newBlock ], 0, clientId );
+				insertBlocks([newBlock], 0, clientId);
 			}
-		} else if ( hasMap ) {
+		} else if (hasMap) {
 			// If disabling the showMap toggle, remove the existing map.
-			removeBlocks( [ hasMap.clientId ] );
+			removeBlocks([hasMap.clientId]);
 		}
-	}, [ showMap, JSON.stringify( locations ) ] );
+	}, [showMap, JSON.stringify(locations)]);
 
 	/**
 	 * Guard against accidentally deleting the list container block.
 	 */
-	useEffect( () => {
-		if ( ! queryMode && ! list ) {
+	useEffect(() => {
+		if (!queryMode && !list) {
 			// Create a new map at the bottom of the list.
-			const newBlock = createBlock( 'newspack-listings/list-container' );
+			const newBlock = createBlock('newspack-listings/list-container');
 
-			insertBlocks( [ newBlock ], null, clientId );
+			insertBlocks([newBlock], null, clientId);
 		}
-	}, [ list ] );
+	}, [list]);
 
 	/**
 	 * Prevent focusing of "invisible" List Container wrapper block.
 	 * Passes the focusing of List Container to this parent Curated List block.
 	 */
-	useEffect( () => {
-		if ( list && selectedBlock === list.clientId ) {
-			selectBlock( clientId );
+	useEffect(() => {
+		if (list && selectedBlock === list.clientId) {
+			selectBlock(clientId);
 		}
-	}, [ selectedBlock ] );
+	}, [selectedBlock]);
 
 	/**
 	 * Determine if the background color is dark or light.
 	 */
-	useEffect( () => {
-		if ( backgroundColor ) {
-			const contrastRatio = getContrastRatio( backgroundColor );
+	useEffect(() => {
+		if (backgroundColor) {
+			const contrastRatio = getContrastRatio(backgroundColor);
 
-			if ( contrastRatio < 5 ) {
-				return setAttributes( { hasDarkBackground: true } );
+			if (contrastRatio < 5) {
+				return setAttributes({ hasDarkBackground: true });
 			}
 		}
 
-		setAttributes( { hasDarkBackground: false } );
-	}, [ backgroundColor ] );
+		setAttributes({ hasDarkBackground: false });
+	}, [backgroundColor]);
 
 	/**
 	 * Sync parent attributes to inner blocks.
 	 */
-	useEffect( () => {
-		if ( list ) {
+	useEffect(() => {
+		if (list) {
 			updateBlockAttributes(
-				[ list.clientId ].concat( list.innerBlocks.map( innerBlock => innerBlock.clientId ) ), // Array of client IDs for both list container and individual listings.
+				[list.clientId].concat(
+					list.innerBlocks.map(innerBlock => innerBlock.clientId)
+				), // Array of client IDs for both list container and individual listings.
 				attributes,
 				false
 			);
 		}
-	}, [ JSON.stringify( attributes ) ] );
+	}, [JSON.stringify(attributes)]);
 
 	/**
 	 * Render the results of the listing query.
@@ -304,12 +328,19 @@ const CuratedListEditorComponent = ( {
 	 * @param {Object} listing Post object for listing to show.
 	 * @param {number} index   Index of the item in the array.
 	 */
-	const renderQueriedListings = ( listing, index ) => (
-		<div key={ index } className="newspack-listings__listing-editor newspack-listings__listing">
-			<Listing attributes={ attributes } error={ error } post={ listing } />
+	const renderQueriedListings = (listing, index) => (
+		<div
+			key={index}
+			className="newspack-listings__listing-editor newspack-listings__listing"
+		>
+			<Listing attributes={attributes} error={error} post={listing} />
 			{
-				<Button isLink href={ `/wp-admin/post.php?post=${ listing.id }&action=edit` } target="_blank">
-					{ __( 'Edit this listing', 'newspack-listings' ) }
+				<Button
+					isLink
+					href={`/wp-admin/post.php?post=${listing.id}&action=edit`}
+					target="_blank"
+				>
+					{__('Edit this listing', 'newspack-listings')}
 				</Button>
 			}
 		</div>
@@ -322,7 +353,13 @@ const CuratedListEditorComponent = ( {
 	 * @return {boolean} True if the data is valid location data, false if not.
 	 */
 	const isValidLocation = location => {
-		if ( ! location || ! location.id || ! location.coordinates || ! location.coordinates.latitude || ! location.coordinates.longitude ) {
+		if (
+			!location ||
+			!location.id ||
+			!location.coordinates ||
+			!location.coordinates.latitude ||
+			!location.coordinates.longitude
+		) {
 			return false;
 		}
 
@@ -335,300 +372,432 @@ const CuratedListEditorComponent = ( {
 	const imageSizeOptions = [
 		{
 			value: 1,
-			label: /* translators: label for small size option */ __( 'Small', 'newspack-listings' ),
-			shortName: /* translators: abbreviation for small size */ __( 'S', 'newspack-listings' ),
+			label: /* translators: label for small size option */ __(
+				'Small',
+				'newspack-listings'
+			),
+			shortName: /* translators: abbreviation for small size */ __(
+				'S',
+				'newspack-listings'
+			),
 		},
 		{
 			value: 2,
-			label: /* translators: label for medium size option */ __( 'Medium', 'newspack-listings' ),
-			shortName: /* translators: abbreviation for medium size */ __( 'M', 'newspack-listings' ),
+			label: /* translators: label for medium size option */ __(
+				'Medium',
+				'newspack-listings'
+			),
+			shortName: /* translators: abbreviation for medium size */ __(
+				'M',
+				'newspack-listings'
+			),
 		},
 		{
 			value: 3,
-			label: /* translators: label for large size option */ __( 'Large', 'newspack-listings' ),
-			shortName: /* translators: abbreviation for large size */ __( 'L', 'newspack-listings' ),
+			label: /* translators: label for large size option */ __(
+				'Large',
+				'newspack-listings'
+			),
+			shortName: /* translators: abbreviation for large size */ __(
+				'L',
+				'newspack-listings'
+			),
 		},
 		{
 			value: 4,
-			label: /* translators: label for extra large size option */ __( 'Extra Large', 'newspack-listings' ),
-			shortName: /* translators: abbreviation for extra large size */ __( 'XL', 'newspack-listings' ),
+			label: /* translators: label for extra large size option */ __(
+				'Extra Large',
+				'newspack-listings'
+			),
+			shortName: /* translators: abbreviation for extra large size */ __(
+				'XL',
+				'newspack-listings'
+			),
 		},
 	];
 
 	/**
 	 * Show a hint to the user if there are no listings that can be added to the list.
 	 */
-	if ( isEmpty ) {
+	if (isEmpty) {
 		return (
-			<Placeholder icon={ <List /> } label={ __( 'Curated List', 'newspack-listings' ) }>
-				<Notice isDismissible={ false }>{ __( 'Your site doesn’t have any listings. Create some to get started.' ) }</Notice>
-			</Placeholder>
+			<div {...blockProps}>
+				<Placeholder
+					icon={<List />}
+					label={__('Curated List', 'newspack-listings')}
+				>
+					<Notice isDismissible={false}>
+						{__(
+							'Your site doesn\u2019t have any listings. Create some to get started.'
+						)}
+					</Notice>
+				</Placeholder>
+			</div>
 		);
 	}
 
 	// Let user pick Query or Specific mode on startup.
-	if ( startup ) {
+	if (startup) {
 		return (
-			<div className="newspack-listings__placeholder">
-				<BlockVariationPicker
-					icon={ <List /> }
-					label={ __( 'Curated List', 'newspack-listings' ) }
-					instructions={ __( 'Select the type of list to start with.' ) }
-					onSelect={ variation => {
-						if ( variation.name && 'query' === variation.name ) {
-							setAttributes( {
-								queryMode: true,
-								startup: false,
-							} );
-						} else {
-							setAttributes( {
-								startup: false,
-							} );
-						}
-					} }
-					variations={ [
-						{
-							name: 'query',
-							title: __( 'Query', 'newspack-listings' ),
-							icon: <Icon icon={ loop } />,
-						},
-						{
-							name: 'specific',
-							title: __( 'Specific Listings', 'newspack-listings' ),
-							icon: <Icon icon={ postList } />,
-						},
-					] }
-				/>
+			<div {...blockProps}>
+				<div className="newspack-listings__placeholder">
+					<BlockVariationPicker
+						icon={<List />}
+						label={__('Curated List', 'newspack-listings')}
+						instructions={__(
+							'Select the type of list to start with.'
+						)}
+						onSelect={variation => {
+							if (variation.name && 'query' === variation.name) {
+								setAttributes({
+									queryMode: true,
+									startup: false,
+								});
+							} else {
+								setAttributes({
+									startup: false,
+								});
+							}
+						}}
+						variations={[
+							{
+								name: 'query',
+								title: __('Query', 'newspack-listings'),
+								icon: <Icon icon={loop} />,
+							},
+							{
+								name: 'specific',
+								title: __(
+									'Specific Listings',
+									'newspack-listings'
+								),
+								icon: <Icon icon={postList} />,
+							},
+						]}
+					/>
+				</div>
 			</div>
 		);
 	}
 
 	return (
-		<>
+		<div {...blockProps}>
 			<InspectorControls>
-				{ queryMode && (
-					<PanelBody title={ __( 'Query Settings', 'newspack-listings' ) }>
+				{queryMode && (
+					<PanelBody
+						title={__('Query Settings', 'newspack-listings')}
+					>
 						<SidebarQueryControls
-							disabled={ isFetching }
-							setAttributes={ setAttributes }
-							queryOptions={ queryOptions }
-							showAuthor={ showAuthor }
-							showLoadMore={ showLoadMore }
-							loadMoreText={ loadMoreText }
+							disabled={isFetching}
+							setAttributes={setAttributes}
+							queryOptions={queryOptions}
+							showAuthor={showAuthor}
+							showLoadMore={showLoadMore}
+							loadMoreText={loadMoreText}
 						/>
 					</PanelBody>
-				) }
-				<PanelBody title={ __( 'List Settings', 'newspack-listings' ) }>
+				)}
+				<PanelBody title={__('List Settings', 'newspack-listings')}>
 					<PanelRow>
 						<ToggleControl
-							label={ __( 'Show list item numbers', 'newspack-listings' ) }
-							checked={ showNumbers }
-							onChange={ () => setAttributes( { showNumbers: ! showNumbers } ) }
+							label={__(
+								'Show list item numbers',
+								'newspack-listings'
+							)}
+							checked={showNumbers}
+							onChange={() =>
+								setAttributes({ showNumbers: !showNumbers })
+							}
 						/>
 					</PanelRow>
 
-					{ canUseMapBlock && (
+					{canUseMapBlock && (
 						<PanelRow>
 							<ToggleControl
-								label={ __( 'Show map', 'newspack-listings' ) }
-								help={ sprintf(
+								label={__('Show map', 'newspack-listings')}
+								help={sprintf(
 									// translators: %d: maximum number of items to display on the map.
 									__(
 										'The map will display locations for up to %d items in the list, regardless of the current number of items shown.',
 										'newspack-listings'
 									),
 									MAX_EDITOR_ITEMS
-								) }
-								checked={ showMap }
-								onChange={ () => setAttributes( { showMap: ! showMap } ) }
+								)}
+								checked={showMap}
+								onChange={() =>
+									setAttributes({ showMap: !showMap })
+								}
 							/>
 						</PanelRow>
-					) }
+					)}
 					<PanelRow>
 						<ToggleControl
-							label={ __( 'Show sort UI', 'newspack-listings' ) }
-							checked={ showSortUi }
-							onChange={ () => setAttributes( { showSortUi: ! showSortUi } ) }
+							label={__('Show sort UI', 'newspack-listings')}
+							checked={showSortUi}
+							onChange={() =>
+								setAttributes({ showSortUi: !showSortUi })
+							}
 						/>
 					</PanelRow>
 				</PanelBody>
-				<PanelBody title={ __( 'Featured Image Settings', 'newspack-listings' ) }>
+				<PanelBody
+					title={__('Featured Image Settings', 'newspack-listings')}
+				>
 					<PanelRow>
 						<ToggleControl
-							label={ __( 'Show Featured Image', 'newspack-listings' ) }
-							checked={ showImage }
-							onChange={ () => setAttributes( { showImage: ! showImage } ) }
+							label={__(
+								'Show Featured Image',
+								'newspack-listings'
+							)}
+							checked={showImage}
+							onChange={() =>
+								setAttributes({ showImage: !showImage })
+							}
 						/>
 					</PanelRow>
 
-					{ showImage && (
+					{showImage && (
 						<Fragment>
 							<PanelRow>
 								<ToggleControl
-									label={ __( 'Show Featured Image Caption', 'newspack-listings' ) }
-									checked={ showCaption }
-									onChange={ () => setAttributes( { showCaption: ! showCaption } ) }
+									label={__(
+										'Show Featured Image Caption',
+										'newspack-listings'
+									)}
+									checked={showCaption}
+									onChange={() =>
+										setAttributes({
+											showCaption: !showCaption,
+										})
+									}
 								/>
 							</PanelRow>
 							<SelectControl
-								label={ __( 'Featured Image Position', 'newspack-listings' ) }
-								value={ mediaPosition }
-								onChange={ value => setAttributes( { mediaPosition: value } ) }
-								options={ [
-									{ label: __( 'Top', 'newspack-listings' ), value: 'top' },
-									{ label: __( 'Left', 'newspack-listings' ), value: 'left' },
-									{ label: __( 'Right', 'newspack-listings' ), value: 'right' },
-								] }
+								label={__(
+									'Featured Image Position',
+									'newspack-listings'
+								)}
+								value={mediaPosition}
+								onChange={value =>
+									setAttributes({ mediaPosition: value })
+								}
+								options={[
+									{
+										label: __('Top', 'newspack-listings'),
+										value: 'top',
+									},
+									{
+										label: __('Left', 'newspack-listings'),
+										value: 'left',
+									},
+									{
+										label: __('Right', 'newspack-listings'),
+										value: 'right',
+									},
+								]}
 							/>
 						</Fragment>
-					) }
+					)}
 
-					{ showImage && mediaPosition !== 'top' && mediaPosition !== 'behind' && (
-						<Fragment>
-							<BaseControl label={ __( 'Featured Image Size', 'newspack-listings' ) } id="newspackfeatured-image-size">
-								<PanelRow>
-									<ButtonGroup id="newspackfeatured-image-size" aria-label={ __( 'Featured Image Size', 'newspack-listings' ) }>
-										{ imageSizeOptions.map( option => {
-											const isCurrent = imageScale === option.value;
-											return (
-												<Button
-													isLarge
-													isPrimary={ isCurrent }
-													aria-pressed={ isCurrent }
-													aria-label={ option.label }
-													key={ option.value }
-													onClick={ () => setAttributes( { imageScale: option.value } ) }
-												>
-													{ option.shortName }
-												</Button>
-											);
-										} ) }
-									</ButtonGroup>
-								</PanelRow>
-							</BaseControl>
-						</Fragment>
-					) }
+					{showImage &&
+						mediaPosition !== 'top' &&
+						mediaPosition !== 'behind' && (
+							<Fragment>
+								<BaseControl
+									label={__(
+										'Featured Image Size',
+										'newspack-listings'
+									)}
+									id="newspackfeatured-image-size"
+								>
+									<PanelRow>
+										<ButtonGroup
+											id="newspackfeatured-image-size"
+											aria-label={__(
+												'Featured Image Size',
+												'newspack-listings'
+											)}
+										>
+											{imageSizeOptions.map(option => {
+												const isCurrent =
+													imageScale === option.value;
+												return (
+													<Button
+														isLarge
+														isPrimary={isCurrent}
+														aria-pressed={isCurrent}
+														aria-label={
+															option.label
+														}
+														key={option.value}
+														onClick={() =>
+															setAttributes({
+																imageScale:
+																	option.value,
+															})
+														}
+													>
+														{option.shortName}
+													</Button>
+												);
+											})}
+										</ButtonGroup>
+									</PanelRow>
+								</BaseControl>
+							</Fragment>
+						)}
 
-					{ showImage && mediaPosition === 'behind' && (
+					{showImage && mediaPosition === 'behind' && (
 						<RangeControl
-							label={ __( 'Minimum height', 'newspack-listings' ) }
-							help={ __(
+							label={__('Minimum height', 'newspack-listings')}
+							help={__(
 								"Sets a minimum height for the block, using a percentage of the screen's current height.",
 								'newspack-listings'
-							) }
-							value={ minHeight }
-							onChange={ _minHeight => setAttributes( { minHeight: _minHeight } ) }
-							min={ 0 }
-							max={ 100 }
+							)}
+							value={minHeight}
+							onChange={_minHeight =>
+								setAttributes({ minHeight: _minHeight })
+							}
+							min={0}
+							max={100}
 							required
 						/>
-					) }
+					)}
 				</PanelBody>
-				<PanelBody title={ __( 'Post Control Settings', 'newspack-listings' ) }>
+				<PanelBody
+					title={__('Post Control Settings', 'newspack-listings')}
+				>
 					<PanelRow>
 						<ToggleControl
-							label={ __( 'Show Excerpt', 'newspack-listings' ) }
-							checked={ showExcerpt }
-							onChange={ () => setAttributes( { showExcerpt: ! showExcerpt } ) }
+							label={__('Show Excerpt', 'newspack-listings')}
+							checked={showExcerpt}
+							onChange={() =>
+								setAttributes({ showExcerpt: !showExcerpt })
+							}
 						/>
 					</PanelRow>
 					<RangeControl
 						className="type-scale-slider"
-						label={ __( 'Type Scale', 'newspack-listings' ) }
-						value={ typeScale }
-						onChange={ _typeScale => setAttributes( { typeScale: _typeScale } ) }
-						min={ 1 }
-						max={ 10 }
+						label={__('Type Scale', 'newspack-listings')}
+						value={typeScale}
+						onChange={_typeScale =>
+							setAttributes({ typeScale: _typeScale })
+						}
+						min={1}
+						max={10}
 						required
 					/>
 				</PanelBody>
 				<PanelColorSettings
-					title={ __( 'Color Settings', 'newspack-listings' ) }
-					initialOpen={ true }
-					colorSettings={ [
+					title={__('Color Settings', 'newspack-listings')}
+					initialOpen={true}
+					colorSettings={[
 						{
 							value: textColor,
-							onChange: value => setAttributes( { textColor: value } ),
-							label: __( 'Text Color', 'newspack-listings' ),
+							onChange: value =>
+								setAttributes({ textColor: value }),
+							label: __('Text Color', 'newspack-listings'),
 						},
 						{
 							value: backgroundColor,
-							onChange: value => setAttributes( { backgroundColor: value } ),
-							label: __( 'Background Color', 'newspack-listings' ),
+							onChange: value =>
+								setAttributes({ backgroundColor: value }),
+							label: __('Background Color', 'newspack-listings'),
 						},
-					] }
+					]}
 				/>
-				<PanelBody title={ __( 'Meta Settings', 'newspack-listings' ) }>
+				<PanelBody title={__('Meta Settings', 'newspack-listings')}>
 					<PanelRow>
 						<ToggleControl
-							label={ __( 'Show Author', 'newspack-listings' ) }
-							checked={ showAuthor }
-							onChange={ () => setAttributes( { showAuthor: ! showAuthor } ) }
+							label={__('Show Author', 'newspack-listings')}
+							checked={showAuthor}
+							onChange={() =>
+								setAttributes({ showAuthor: !showAuthor })
+							}
 						/>
 					</PanelRow>
 					<PanelRow>
 						<ToggleControl
-							label={ __( 'Show Category', 'newspack-listings' ) }
-							checked={ showCategory }
-							onChange={ () => setAttributes( { showCategory: ! showCategory } ) }
+							label={__('Show Category', 'newspack-listings')}
+							checked={showCategory}
+							onChange={() =>
+								setAttributes({ showCategory: !showCategory })
+							}
 						/>
 					</PanelRow>
 					<PanelRow>
 						<ToggleControl
-							label={ __( 'Show Tags', 'newspack-listings' ) }
-							checked={ showTags }
-							onChange={ () => setAttributes( { showTags: ! showTags } ) }
+							label={__('Show Tags', 'newspack-listings')}
+							checked={showTags}
+							onChange={() =>
+								setAttributes({ showTags: !showTags })
+							}
 						/>
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
-			<div className="newspack-listings__curated-list-editor">
-				<div
-					className={ classes.join( ' ' ) }
-					style={ {
-						backgroundColor: backgroundColor || '#fff',
-						color: textColor || '#000',
-					} }
-				>
-					{ queryMode && error && (
-						<Notice className="newspack-listings__error" status="error" isDismissible={ false }>
-							{ error }
-						</Notice>
-					) }
-					<InnerBlocks
-						allowedBlocks={ [ 'jetpack/map', 'newspack-listings/list-container' ] }
-						template={ [ [ 'newspack-listings/list-container' ] ] } // Start with an empty list only.
-						templateInsertUpdatesSelection={ false }
-						renderAppender={ () => null } // We want to discourage editors from adding blocks in this top-level wrapper, but we can't lock the template because we still need to be able to programmatically add or remove map blocks.
-					/>
-					{
-						// If in query mode and while fetching posts.
-						isFetching && queryMode && (
-							<Placeholder>
-								<Spinner />
-							</Placeholder>
-						)
-					}
-					{
-						// If in query mode, show the queried listings.
-						! isFetching && queryMode && queriedListings.map( renderQueriedListings )
-					}
-					{ ! isFetching && queryMode && showLoadMore && queryOptions.maxItems < queriedListings.length && (
-						<Button className="newspack-listings__load-more" isPrimary>
-							{ loadMoreText }
+			<div
+				className={classes.join(' ')}
+				style={{
+					backgroundColor: backgroundColor || '#fff',
+					color: textColor || '#000',
+				}}
+			>
+				{queryMode && error && (
+					<Notice
+						className="newspack-listings__error"
+						status="error"
+						isDismissible={false}
+					>
+						{error}
+					</Notice>
+				)}
+				<InnerBlocks
+					allowedBlocks={[
+						'jetpack/map',
+						'newspack-listings/list-container',
+					]}
+					template={[['newspack-listings/list-container']]} // Start with an empty list only.
+					templateInsertUpdatesSelection={false}
+					renderAppender={() => null} // We want to discourage editors from adding blocks in this top-level wrapper, but we can't lock the template because we still need to be able to programmatically add or remove map blocks.
+				/>
+				{
+					// If in query mode and while fetching posts.
+					isFetching && queryMode && (
+						<Placeholder>
+							<Spinner />
+						</Placeholder>
+					)
+				}
+				{
+					// If in query mode, show the queried listings.
+					!isFetching &&
+						queryMode &&
+						queriedListings.map(renderQueriedListings)
+				}
+				{!isFetching &&
+					queryMode &&
+					showLoadMore &&
+					queryOptions.maxItems < queriedListings.length && (
+						<Button
+							className="newspack-listings__load-more"
+							isPrimary
+						>
+							{loadMoreText}
 						</Button>
-					) }
-				</div>
+					)}
 			</div>
-		</>
+		</div>
 	);
 };
 
-const mapStateToProps = ( select, ownProps ) => {
-	const { getBlocksByClientId, getSelectedBlockClientId } = select( 'core/block-editor' );
-	const { getBlockType } = select( 'core/blocks' );
-	const innerBlocks = getBlocksByClientId( ownProps.clientId )[ 0 ].innerBlocks || [];
-	const canUseMapBlock = !! getBlockType( 'jetpack/map' ); // Check for existence of Jetpack Map block before enabling location-based features.
+const mapStateToProps = (select, ownProps) => {
+	const { getBlocksByClientId, getSelectedBlockClientId } =
+		select('core/block-editor');
+	const { getBlockType } = select('core/blocks');
+	const innerBlocks =
+		getBlocksByClientId(ownProps.clientId)[0].innerBlocks || [];
+	const canUseMapBlock = !!getBlockType('jetpack/map'); // Check for existence of Jetpack Map block before enabling location-based features.
 
 	return {
 		canUseMapBlock,
@@ -638,7 +807,8 @@ const mapStateToProps = ( select, ownProps ) => {
 };
 
 const mapDispatchToProps = dispatch => {
-	const { insertBlocks, removeBlocks, selectBlock, updateBlockAttributes } = dispatch( 'core/block-editor' );
+	const { insertBlocks, removeBlocks, selectBlock, updateBlockAttributes } =
+		dispatch('core/block-editor');
 
 	return {
 		insertBlocks,
@@ -648,4 +818,7 @@ const mapDispatchToProps = dispatch => {
 	};
 };
 
-export const CuratedListEditor = compose( [ withSelect( mapStateToProps ), withDispatch( mapDispatchToProps ) ] )( CuratedListEditorComponent );
+export const CuratedListEditor = compose([
+	withSelect(mapStateToProps),
+	withDispatch(mapDispatchToProps),
+])(CuratedListEditorComponent);

--- a/src/blocks/curated-list/edit.js
+++ b/src/blocks/curated-list/edit.js
@@ -592,39 +592,39 @@ const CuratedListEditorComponent = ( {
 			<div { ...blockProps }>
 				<div
 					className={ classes.join( ' ' ) }
-				style={ {
-					backgroundColor: backgroundColor || '#fff',
-					color: textColor || '#000',
-				} }
-			>
-				{ queryMode && error && (
-					<Notice className="newspack-listings__error" status="error" isDismissible={ false }>
-						{ error }
-					</Notice>
-				) }
-				<InnerBlocks
-					allowedBlocks={ [ 'jetpack/map', 'newspack-listings/list-container' ] }
-					template={ [ [ 'newspack-listings/list-container' ] ] } // Start with an empty list only.
-					templateInsertUpdatesSelection={ false }
-					renderAppender={ () => null } // We want to discourage editors from adding blocks in this top-level wrapper, but we can't lock the template because we still need to be able to programmatically add or remove map blocks.
-				/>
-				{
-					// If in query mode and while fetching posts.
-					isFetching && queryMode && (
-						<Placeholder>
-							<Spinner />
-						</Placeholder>
-					)
-				}
-				{
-					// If in query mode, show the queried listings.
-					! isFetching && queryMode && queriedListings.map( renderQueriedListings )
-				}
-				{ ! isFetching && queryMode && showLoadMore && queryOptions.maxItems < queriedListings.length && (
-					<Button className="newspack-listings__load-more" isPrimary>
-						{ loadMoreText }
-					</Button>
-				) }
+					style={ {
+						backgroundColor: backgroundColor || '#fff',
+						color: textColor || '#000',
+					} }
+				>
+					{ queryMode && error && (
+						<Notice className="newspack-listings__error" status="error" isDismissible={ false }>
+							{ error }
+						</Notice>
+					) }
+					<InnerBlocks
+						allowedBlocks={ [ 'jetpack/map', 'newspack-listings/list-container' ] }
+						template={ [ [ 'newspack-listings/list-container' ] ] } // Start with an empty list only.
+						templateInsertUpdatesSelection={ false }
+						renderAppender={ () => null } // We want to discourage editors from adding blocks in this top-level wrapper, but we can't lock the template because we still need to be able to programmatically add or remove map blocks.
+					/>
+					{
+						// If in query mode and while fetching posts.
+						isFetching && queryMode && (
+							<Placeholder>
+								<Spinner />
+							</Placeholder>
+						)
+					}
+					{
+						// If in query mode, show the queried listings.
+						! isFetching && queryMode && queriedListings.map( renderQueriedListings )
+					}
+					{ ! isFetching && queryMode && showLoadMore && queryOptions.maxItems < queriedListings.length && (
+						<Button className="newspack-listings__load-more" isPrimary>
+							{ loadMoreText }
+						</Button>
+					) }
 				</div>
 			</div>
 		</>

--- a/src/blocks/curated-list/edit.js
+++ b/src/blocks/curated-list/edit.js
@@ -411,7 +411,7 @@ const CuratedListEditorComponent = ( {
 	}
 
 	return (
-		<div { ...blockProps }>
+		<>
 			<InspectorControls>
 				{ queryMode && (
 					<PanelBody title={ __( 'Query Settings', 'newspack-listings' ) }>
@@ -589,8 +589,9 @@ const CuratedListEditorComponent = ( {
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
-			<div
-				className={ classes.join( ' ' ) }
+			<div { ...blockProps }>
+				<div
+					className={ classes.join( ' ' ) }
 				style={ {
 					backgroundColor: backgroundColor || '#fff',
 					color: textColor || '#000',
@@ -624,8 +625,9 @@ const CuratedListEditorComponent = ( {
 						{ loadMoreText }
 					</Button>
 				) }
+				</div>
 			</div>
-		</div>
+		</>
 	);
 };
 

--- a/src/blocks/curated-list/edit.js
+++ b/src/blocks/curated-list/edit.js
@@ -37,11 +37,7 @@ import { Icon, loop, postList } from '@wordpress/icons';
 import { Listing } from '../listing/listing';
 import { SidebarQueryControls } from '../../components';
 import { List } from '../../svg';
-import {
-	getContrastRatio,
-	getCuratedListClasses,
-	useDidMount,
-} from '../../editor/utils';
+import { getContrastRatio, getCuratedListClasses, useDidMount } from '../../editor/utils';
 
 /**
  * Debounced fetchPosts function outside of component scope.
@@ -56,7 +52,7 @@ let debouncedFetchPosts;
  */
 const MAX_EDITOR_ITEMS = 100;
 
-const CuratedListEditorComponent = ({
+const CuratedListEditorComponent = ( {
 	attributes,
 	canUseMapBlock,
 	clientId,
@@ -68,13 +64,13 @@ const CuratedListEditorComponent = ({
 	selectedBlock,
 	setAttributes,
 	updateBlockAttributes,
-}) => {
-	const [error, setError] = useState(null);
-	const [isFetching, setIsFetching] = useState(false);
-	const [locations, setLocations] = useState([]);
-	const blockProps = useBlockProps({
+} ) => {
+	const [ error, setError ] = useState( null );
+	const [ isFetching, setIsFetching ] = useState( false );
+	const [ locations, setLocations ] = useState( [] );
+	const blockProps = useBlockProps( {
 		className: 'newspack-listings__curated-list-editor',
-	});
+	} );
 	const {
 		showNumbers,
 		showMap,
@@ -99,14 +95,10 @@ const CuratedListEditorComponent = ({
 		loadMoreText,
 	} = attributes;
 
-	const isEmpty = !!window.newspack_listings_data.no_listings || false;
-	const list = innerBlocks.find(
-		innerBlock => innerBlock.name === 'newspack-listings/list-container'
-	);
-	const hasMap = innerBlocks.find(
-		innerBlock => innerBlock.name === 'jetpack/map'
-	);
-	const classes = getCuratedListClasses(blockProps.className, attributes);
+	const isEmpty = !! window.newspack_listings_data.no_listings || false;
+	const list = innerBlocks.find( innerBlock => innerBlock.name === 'newspack-listings/list-container' );
+	const hasMap = innerBlocks.find( innerBlock => innerBlock.name === 'jetpack/map' );
+	const classes = getCuratedListClasses( blockProps.className, attributes );
 	const initialRender = useDidMount();
 
 	/**
@@ -116,211 +108,198 @@ const CuratedListEditorComponent = ({
 	 * @return {void}
 	 */
 	const fetchPosts = async query => {
-		if (isFetching || !queryMode) {
+		if ( isFetching || ! queryMode ) {
 			return;
 		}
 
-		setIsFetching(true);
+		setIsFetching( true );
 
 		try {
-			setError(null);
-			const posts = await apiFetch({
-				path: addQueryArgs('/newspack-listings/v1/listings', {
+			setError( null );
+			const posts = await apiFetch( {
+				path: addQueryArgs( '/newspack-listings/v1/listings', {
 					query: { maxItems: MAX_EDITOR_ITEMS, ...query }, // Get up to MAX_EDITOR_ITEMS listings in the editor so we can show all locations.
-					_fields:
-						'id,title,author,category,tags,excerpt,media,meta,type,sponsors,classes',
-				}),
-			});
-			setAttributes({ listingIds: posts.map(post => post.id) });
-			setAttributes({ queriedListings: posts });
+					_fields: 'id,title,author,category,tags,excerpt,media,meta,type,sponsors,classes',
+				} ),
+			} );
+			setAttributes( { listingIds: posts.map( post => post.id ) } );
+			setAttributes( { queriedListings: posts } );
 
-			if (0 === posts.length) {
+			if ( 0 === posts.length ) {
 				throw 'No posts matching query options. Try selecting different or less specific query options.';
 			}
-		} catch (e) {
-			setError(e);
+		} catch ( e ) {
+			setError( e );
 		}
 
-		setIsFetching(false);
+		setIsFetching( false );
 	};
 
 	/**
 	 * If changing query options, fetch listing posts that match the query.
 	 */
-	useEffect(() => {
-		if (initialRender) {
-			fetchPosts(queryOptions);
+	useEffect( () => {
+		if ( initialRender ) {
+			fetchPosts( queryOptions );
 		} else {
 			// Debounced version of fetchPosts to minimize consecutive executions.
-			clearTimeout(debouncedFetchPosts);
-			debouncedFetchPosts = setTimeout(() => {
-				fetchPosts(queryOptions);
-			}, 500);
+			clearTimeout( debouncedFetchPosts );
+			debouncedFetchPosts = setTimeout( () => {
+				fetchPosts( queryOptions );
+			}, 500 );
 		}
-	}, [JSON.stringify(queryOptions), queryMode]);
+	}, [ JSON.stringify( queryOptions ), queryMode ] );
 
 	/**
 	 * Set isSelected attribute so child blocks know selected state.
 	 */
-	useEffect(() => {
-		setAttributes({ isSelected });
-	}, [isSelected]);
+	useEffect( () => {
+		setAttributes( { isSelected } );
+	}, [ isSelected ] );
 
 	/**
 	 * Update locations in component state. This lets us keep the map block in sync with listing items.
 	 */
-	useEffect(() => {
-		if (!canUseMapBlock) {
+	useEffect( () => {
+		if ( ! canUseMapBlock ) {
 			return;
 		}
 
 		let newLocations = [];
 
 		// Only build locations array if we have any listings, and the Jetpack Maps block exists.
-		if (queryMode) {
-			newLocations = queriedListings.reduce((acc, queriedListing) => {
-				if (
-					queriedListing.meta &&
-					queriedListing.meta.newspack_listings_locations
-				) {
-					queriedListing.meta.newspack_listings_locations.map(
-						location => {
-							if (isValidLocation(location)) {
-								acc.push(location);
-							}
-
-							return acc;
+		if ( queryMode ) {
+			newLocations = queriedListings.reduce( ( acc, queriedListing ) => {
+				if ( queriedListing.meta && queriedListing.meta.newspack_listings_locations ) {
+					queriedListing.meta.newspack_listings_locations.map( location => {
+						if ( isValidLocation( location ) ) {
+							acc.push( location );
 						}
-					);
+
+						return acc;
+					} );
 				}
 
 				return acc;
-			}, []);
+			}, [] );
 		} else {
 			newLocations = list
-				? list.innerBlocks.reduce((acc, innerBlock) => {
-						if (
-							innerBlock.attributes.locations &&
-							0 < innerBlock.attributes.locations.length
-						) {
-							innerBlock.attributes.locations.map(location => {
-								if (isValidLocation(location)) {
-									acc.push(location);
+				? list.innerBlocks.reduce( ( acc, innerBlock ) => {
+						if ( innerBlock.attributes.locations && 0 < innerBlock.attributes.locations.length ) {
+							innerBlock.attributes.locations.map( location => {
+								if ( isValidLocation( location ) ) {
+									acc.push( location );
 								}
 
 								return acc;
-							});
+							} );
 						}
 						return acc;
-					}, [])
+				  }, [] )
 				: [];
 		}
 
-		setLocations(newLocations);
-	}, [list, JSON.stringify(queriedListings), queryMode]);
+		setLocations( newLocations );
+	}, [ list, JSON.stringify( queriedListings ), queryMode ] );
 
 	/**
 	 * Keep track of post IDs of all nested listings in specific listings mode.
 	 */
-	useEffect(() => {
-		if (!queryMode && list) {
-			const newListingIds = list.innerBlocks.map(innerBlock =>
-				parseInt(innerBlock.attributes.listing)
-			);
+	useEffect( () => {
+		if ( ! queryMode && list ) {
+			const newListingIds = list.innerBlocks.map( innerBlock => parseInt( innerBlock.attributes.listing ) );
 
-			setAttributes({ listingIds: newListingIds });
+			setAttributes( { listingIds: newListingIds } );
 		}
-	}, [list]);
+	}, [ list ] );
 
 	/**
 	 * Create, update, or remove map when showMap attribute or locations change.
 	 */
-	useEffect(() => {
+	useEffect( () => {
 		// Don't run on the initial render.
-		if (initialRender) {
+		if ( initialRender ) {
 			return;
 		}
 
 		// Don't bother if the Jetpack Maps block doesn't exist.
-		if (!canUseMapBlock) {
+		if ( ! canUseMapBlock ) {
 			return;
 		}
 
 		// If showMap toggle is enabled, update the existing map or create a new one.
-		if (showMap && 0 < locations.length) {
-			if (hasMap) {
+		if ( showMap && 0 < locations.length ) {
+			if ( hasMap ) {
 				// If we already have a map, update it.
-				updateBlockAttributes(hasMap.clientId, { points: locations });
+				updateBlockAttributes( hasMap.clientId, { points: locations } );
 			} else {
 				// Don't add a new map unless we have some locations to show.
-				if (0 === locations.length) {
+				if ( 0 === locations.length ) {
 					return;
 				}
 
 				// Create a new map at the top of the list.
-				const newBlock = createBlock('jetpack/map', {
+				const newBlock = createBlock( 'jetpack/map', {
 					points: locations,
-				});
+				} );
 
-				insertBlocks([newBlock], 0, clientId);
+				insertBlocks( [ newBlock ], 0, clientId );
 			}
-		} else if (hasMap) {
+		} else if ( hasMap ) {
 			// If disabling the showMap toggle, remove the existing map.
-			removeBlocks([hasMap.clientId]);
+			removeBlocks( [ hasMap.clientId ] );
 		}
-	}, [showMap, JSON.stringify(locations)]);
+	}, [ showMap, JSON.stringify( locations ) ] );
 
 	/**
 	 * Guard against accidentally deleting the list container block.
 	 */
-	useEffect(() => {
-		if (!queryMode && !list) {
+	useEffect( () => {
+		if ( ! queryMode && ! list ) {
 			// Create a new map at the bottom of the list.
-			const newBlock = createBlock('newspack-listings/list-container');
+			const newBlock = createBlock( 'newspack-listings/list-container' );
 
-			insertBlocks([newBlock], null, clientId);
+			insertBlocks( [ newBlock ], null, clientId );
 		}
-	}, [list]);
+	}, [ list ] );
 
 	/**
 	 * Prevent focusing of "invisible" List Container wrapper block.
 	 * Passes the focusing of List Container to this parent Curated List block.
 	 */
-	useEffect(() => {
-		if (list && selectedBlock === list.clientId) {
-			selectBlock(clientId);
+	useEffect( () => {
+		if ( list && selectedBlock === list.clientId ) {
+			selectBlock( clientId );
 		}
-	}, [selectedBlock]);
+	}, [ selectedBlock ] );
 
 	/**
 	 * Determine if the background color is dark or light.
 	 */
-	useEffect(() => {
-		if (backgroundColor) {
-			const contrastRatio = getContrastRatio(backgroundColor);
+	useEffect( () => {
+		if ( backgroundColor ) {
+			const contrastRatio = getContrastRatio( backgroundColor );
 
-			if (contrastRatio < 5) {
-				return setAttributes({ hasDarkBackground: true });
+			if ( contrastRatio < 5 ) {
+				return setAttributes( { hasDarkBackground: true } );
 			}
 		}
 
-		setAttributes({ hasDarkBackground: false });
-	}, [backgroundColor]);
+		setAttributes( { hasDarkBackground: false } );
+	}, [ backgroundColor ] );
 
 	/**
 	 * Sync parent attributes to inner blocks.
 	 */
-	useEffect(() => {
-		if (list) {
+	useEffect( () => {
+		if ( list ) {
 			updateBlockAttributes(
-				[list.clientId].concat(
-					list.innerBlocks.map(innerBlock => innerBlock.clientId)
-				), // Array of client IDs for both list container and individual listings.
+				[ list.clientId ].concat( list.innerBlocks.map( innerBlock => innerBlock.clientId ) ), // Array of client IDs for both list container and individual listings.
 				attributes,
 				false
 			);
 		}
-	}, [JSON.stringify(attributes)]);
+	}, [ JSON.stringify( attributes ) ] );
 
 	/**
 	 * Render the results of the listing query.
@@ -328,19 +307,12 @@ const CuratedListEditorComponent = ({
 	 * @param {Object} listing Post object for listing to show.
 	 * @param {number} index   Index of the item in the array.
 	 */
-	const renderQueriedListings = (listing, index) => (
-		<div
-			key={index}
-			className="newspack-listings__listing-editor newspack-listings__listing"
-		>
-			<Listing attributes={attributes} error={error} post={listing} />
+	const renderQueriedListings = ( listing, index ) => (
+		<div key={ index } className="newspack-listings__listing-editor newspack-listings__listing">
+			<Listing attributes={ attributes } error={ error } post={ listing } />
 			{
-				<Button
-					isLink
-					href={`/wp-admin/post.php?post=${listing.id}&action=edit`}
-					target="_blank"
-				>
-					{__('Edit this listing', 'newspack-listings')}
+				<Button isLink href={ `/wp-admin/post.php?post=${ listing.id }&action=edit` } target="_blank">
+					{ __( 'Edit this listing', 'newspack-listings' ) }
 				</Button>
 			}
 		</div>
@@ -353,13 +325,7 @@ const CuratedListEditorComponent = ({
 	 * @return {boolean} True if the data is valid location data, false if not.
 	 */
 	const isValidLocation = location => {
-		if (
-			!location ||
-			!location.id ||
-			!location.coordinates ||
-			!location.coordinates.latitude ||
-			!location.coordinates.longitude
-		) {
+		if ( ! location || ! location.id || ! location.coordinates || ! location.coordinates.latitude || ! location.coordinates.longitude ) {
 			return false;
 		}
 
@@ -372,108 +338,72 @@ const CuratedListEditorComponent = ({
 	const imageSizeOptions = [
 		{
 			value: 1,
-			label: /* translators: label for small size option */ __(
-				'Small',
-				'newspack-listings'
-			),
-			shortName: /* translators: abbreviation for small size */ __(
-				'S',
-				'newspack-listings'
-			),
+			label: /* translators: label for small size option */ __( 'Small', 'newspack-listings' ),
+			shortName: /* translators: abbreviation for small size */ __( 'S', 'newspack-listings' ),
 		},
 		{
 			value: 2,
-			label: /* translators: label for medium size option */ __(
-				'Medium',
-				'newspack-listings'
-			),
-			shortName: /* translators: abbreviation for medium size */ __(
-				'M',
-				'newspack-listings'
-			),
+			label: /* translators: label for medium size option */ __( 'Medium', 'newspack-listings' ),
+			shortName: /* translators: abbreviation for medium size */ __( 'M', 'newspack-listings' ),
 		},
 		{
 			value: 3,
-			label: /* translators: label for large size option */ __(
-				'Large',
-				'newspack-listings'
-			),
-			shortName: /* translators: abbreviation for large size */ __(
-				'L',
-				'newspack-listings'
-			),
+			label: /* translators: label for large size option */ __( 'Large', 'newspack-listings' ),
+			shortName: /* translators: abbreviation for large size */ __( 'L', 'newspack-listings' ),
 		},
 		{
 			value: 4,
-			label: /* translators: label for extra large size option */ __(
-				'Extra Large',
-				'newspack-listings'
-			),
-			shortName: /* translators: abbreviation for extra large size */ __(
-				'XL',
-				'newspack-listings'
-			),
+			label: /* translators: label for extra large size option */ __( 'Extra Large', 'newspack-listings' ),
+			shortName: /* translators: abbreviation for extra large size */ __( 'XL', 'newspack-listings' ),
 		},
 	];
 
 	/**
 	 * Show a hint to the user if there are no listings that can be added to the list.
 	 */
-	if (isEmpty) {
+	if ( isEmpty ) {
 		return (
-			<div {...blockProps}>
-				<Placeholder
-					icon={<List />}
-					label={__('Curated List', 'newspack-listings')}
-				>
-					<Notice isDismissible={false}>
-						{__(
-							'Your site doesn\u2019t have any listings. Create some to get started.'
-						)}
-					</Notice>
+			<div { ...blockProps }>
+				<Placeholder icon={ <List /> } label={ __( 'Curated List', 'newspack-listings' ) }>
+					<Notice isDismissible={ false }>{ __( 'Your site doesn’t have any listings. Create some to get started.' ) }</Notice>
 				</Placeholder>
 			</div>
 		);
 	}
 
 	// Let user pick Query or Specific mode on startup.
-	if (startup) {
+	if ( startup ) {
 		return (
-			<div {...blockProps}>
+			<div { ...blockProps }>
 				<div className="newspack-listings__placeholder">
 					<BlockVariationPicker
-						icon={<List />}
-						label={__('Curated List', 'newspack-listings')}
-						instructions={__(
-							'Select the type of list to start with.'
-						)}
-						onSelect={variation => {
-							if (variation.name && 'query' === variation.name) {
-								setAttributes({
+						icon={ <List /> }
+						label={ __( 'Curated List', 'newspack-listings' ) }
+						instructions={ __( 'Select the type of list to start with.' ) }
+						onSelect={ variation => {
+							if ( variation.name && 'query' === variation.name ) {
+								setAttributes( {
 									queryMode: true,
 									startup: false,
-								});
+								} );
 							} else {
-								setAttributes({
+								setAttributes( {
 									startup: false,
-								});
+								} );
 							}
-						}}
-						variations={[
+						} }
+						variations={ [
 							{
 								name: 'query',
-								title: __('Query', 'newspack-listings'),
-								icon: <Icon icon={loop} />,
+								title: __( 'Query', 'newspack-listings' ),
+								icon: <Icon icon={ loop } />,
 							},
 							{
 								name: 'specific',
-								title: __(
-									'Specific Listings',
-									'newspack-listings'
-								),
-								icon: <Icon icon={postList} />,
+								title: __( 'Specific Listings', 'newspack-listings' ),
+								icon: <Icon icon={ postList } />,
 							},
-						]}
+						] }
 					/>
 				</div>
 			</div>
@@ -481,285 +411,201 @@ const CuratedListEditorComponent = ({
 	}
 
 	return (
-		<div {...blockProps}>
+		<div { ...blockProps }>
 			<InspectorControls>
-				{queryMode && (
-					<PanelBody
-						title={__('Query Settings', 'newspack-listings')}
-					>
+				{ queryMode && (
+					<PanelBody title={ __( 'Query Settings', 'newspack-listings' ) }>
 						<SidebarQueryControls
-							disabled={isFetching}
-							setAttributes={setAttributes}
-							queryOptions={queryOptions}
-							showAuthor={showAuthor}
-							showLoadMore={showLoadMore}
-							loadMoreText={loadMoreText}
+							disabled={ isFetching }
+							setAttributes={ setAttributes }
+							queryOptions={ queryOptions }
+							showAuthor={ showAuthor }
+							showLoadMore={ showLoadMore }
+							loadMoreText={ loadMoreText }
 						/>
 					</PanelBody>
-				)}
-				<PanelBody title={__('List Settings', 'newspack-listings')}>
+				) }
+				<PanelBody title={ __( 'List Settings', 'newspack-listings' ) }>
 					<PanelRow>
 						<ToggleControl
-							label={__(
-								'Show list item numbers',
-								'newspack-listings'
-							)}
-							checked={showNumbers}
-							onChange={() =>
-								setAttributes({ showNumbers: !showNumbers })
-							}
+							label={ __( 'Show list item numbers', 'newspack-listings' ) }
+							checked={ showNumbers }
+							onChange={ () => setAttributes( { showNumbers: ! showNumbers } ) }
 						/>
 					</PanelRow>
 
-					{canUseMapBlock && (
+					{ canUseMapBlock && (
 						<PanelRow>
 							<ToggleControl
-								label={__('Show map', 'newspack-listings')}
-								help={sprintf(
+								label={ __( 'Show map', 'newspack-listings' ) }
+								help={ sprintf(
 									// translators: %d: maximum number of items to display on the map.
 									__(
 										'The map will display locations for up to %d items in the list, regardless of the current number of items shown.',
 										'newspack-listings'
 									),
 									MAX_EDITOR_ITEMS
-								)}
-								checked={showMap}
-								onChange={() =>
-									setAttributes({ showMap: !showMap })
-								}
+								) }
+								checked={ showMap }
+								onChange={ () => setAttributes( { showMap: ! showMap } ) }
 							/>
 						</PanelRow>
-					)}
+					) }
 					<PanelRow>
 						<ToggleControl
-							label={__('Show sort UI', 'newspack-listings')}
-							checked={showSortUi}
-							onChange={() =>
-								setAttributes({ showSortUi: !showSortUi })
-							}
+							label={ __( 'Show sort UI', 'newspack-listings' ) }
+							checked={ showSortUi }
+							onChange={ () => setAttributes( { showSortUi: ! showSortUi } ) }
 						/>
 					</PanelRow>
 				</PanelBody>
-				<PanelBody
-					title={__('Featured Image Settings', 'newspack-listings')}
-				>
+				<PanelBody title={ __( 'Featured Image Settings', 'newspack-listings' ) }>
 					<PanelRow>
 						<ToggleControl
-							label={__(
-								'Show Featured Image',
-								'newspack-listings'
-							)}
-							checked={showImage}
-							onChange={() =>
-								setAttributes({ showImage: !showImage })
-							}
+							label={ __( 'Show Featured Image', 'newspack-listings' ) }
+							checked={ showImage }
+							onChange={ () => setAttributes( { showImage: ! showImage } ) }
 						/>
 					</PanelRow>
 
-					{showImage && (
+					{ showImage && (
 						<Fragment>
 							<PanelRow>
 								<ToggleControl
-									label={__(
-										'Show Featured Image Caption',
-										'newspack-listings'
-									)}
-									checked={showCaption}
-									onChange={() =>
-										setAttributes({
-											showCaption: !showCaption,
-										})
-									}
+									label={ __( 'Show Featured Image Caption', 'newspack-listings' ) }
+									checked={ showCaption }
+									onChange={ () => setAttributes( { showCaption: ! showCaption } ) }
 								/>
 							</PanelRow>
 							<SelectControl
-								label={__(
-									'Featured Image Position',
-									'newspack-listings'
-								)}
-								value={mediaPosition}
-								onChange={value =>
-									setAttributes({ mediaPosition: value })
-								}
-								options={[
-									{
-										label: __('Top', 'newspack-listings'),
-										value: 'top',
-									},
-									{
-										label: __('Left', 'newspack-listings'),
-										value: 'left',
-									},
-									{
-										label: __('Right', 'newspack-listings'),
-										value: 'right',
-									},
-								]}
+								label={ __( 'Featured Image Position', 'newspack-listings' ) }
+								value={ mediaPosition }
+								onChange={ value => setAttributes( { mediaPosition: value } ) }
+								options={ [
+									{ label: __( 'Top', 'newspack-listings' ), value: 'top' },
+									{ label: __( 'Left', 'newspack-listings' ), value: 'left' },
+									{ label: __( 'Right', 'newspack-listings' ), value: 'right' },
+								] }
 							/>
 						</Fragment>
-					)}
+					) }
 
-					{showImage &&
-						mediaPosition !== 'top' &&
-						mediaPosition !== 'behind' && (
-							<Fragment>
-								<BaseControl
-									label={__(
-										'Featured Image Size',
-										'newspack-listings'
-									)}
-									id="newspackfeatured-image-size"
-								>
-									<PanelRow>
-										<ButtonGroup
-											id="newspackfeatured-image-size"
-											aria-label={__(
-												'Featured Image Size',
-												'newspack-listings'
-											)}
-										>
-											{imageSizeOptions.map(option => {
-												const isCurrent =
-													imageScale === option.value;
-												return (
-													<Button
-														isLarge
-														isPrimary={isCurrent}
-														aria-pressed={isCurrent}
-														aria-label={
-															option.label
-														}
-														key={option.value}
-														onClick={() =>
-															setAttributes({
-																imageScale:
-																	option.value,
-															})
-														}
-													>
-														{option.shortName}
-													</Button>
-												);
-											})}
-										</ButtonGroup>
-									</PanelRow>
-								</BaseControl>
-							</Fragment>
-						)}
+					{ showImage && mediaPosition !== 'top' && mediaPosition !== 'behind' && (
+						<Fragment>
+							<BaseControl label={ __( 'Featured Image Size', 'newspack-listings' ) } id="newspackfeatured-image-size">
+								<PanelRow>
+									<ButtonGroup id="newspackfeatured-image-size" aria-label={ __( 'Featured Image Size', 'newspack-listings' ) }>
+										{ imageSizeOptions.map( option => {
+											const isCurrent = imageScale === option.value;
+											return (
+												<Button
+													isLarge
+													isPrimary={ isCurrent }
+													aria-pressed={ isCurrent }
+													aria-label={ option.label }
+													key={ option.value }
+													onClick={ () => setAttributes( { imageScale: option.value } ) }
+												>
+													{ option.shortName }
+												</Button>
+											);
+										} ) }
+									</ButtonGroup>
+								</PanelRow>
+							</BaseControl>
+						</Fragment>
+					) }
 
-					{showImage && mediaPosition === 'behind' && (
+					{ showImage && mediaPosition === 'behind' && (
 						<RangeControl
-							label={__('Minimum height', 'newspack-listings')}
-							help={__(
+							label={ __( 'Minimum height', 'newspack-listings' ) }
+							help={ __(
 								"Sets a minimum height for the block, using a percentage of the screen's current height.",
 								'newspack-listings'
-							)}
-							value={minHeight}
-							onChange={_minHeight =>
-								setAttributes({ minHeight: _minHeight })
-							}
-							min={0}
-							max={100}
+							) }
+							value={ minHeight }
+							onChange={ _minHeight => setAttributes( { minHeight: _minHeight } ) }
+							min={ 0 }
+							max={ 100 }
 							required
 						/>
-					)}
+					) }
 				</PanelBody>
-				<PanelBody
-					title={__('Post Control Settings', 'newspack-listings')}
-				>
+				<PanelBody title={ __( 'Post Control Settings', 'newspack-listings' ) }>
 					<PanelRow>
 						<ToggleControl
-							label={__('Show Excerpt', 'newspack-listings')}
-							checked={showExcerpt}
-							onChange={() =>
-								setAttributes({ showExcerpt: !showExcerpt })
-							}
+							label={ __( 'Show Excerpt', 'newspack-listings' ) }
+							checked={ showExcerpt }
+							onChange={ () => setAttributes( { showExcerpt: ! showExcerpt } ) }
 						/>
 					</PanelRow>
 					<RangeControl
 						className="type-scale-slider"
-						label={__('Type Scale', 'newspack-listings')}
-						value={typeScale}
-						onChange={_typeScale =>
-							setAttributes({ typeScale: _typeScale })
-						}
-						min={1}
-						max={10}
+						label={ __( 'Type Scale', 'newspack-listings' ) }
+						value={ typeScale }
+						onChange={ _typeScale => setAttributes( { typeScale: _typeScale } ) }
+						min={ 1 }
+						max={ 10 }
 						required
 					/>
 				</PanelBody>
 				<PanelColorSettings
-					title={__('Color Settings', 'newspack-listings')}
-					initialOpen={true}
-					colorSettings={[
+					title={ __( 'Color Settings', 'newspack-listings' ) }
+					initialOpen={ true }
+					colorSettings={ [
 						{
 							value: textColor,
-							onChange: value =>
-								setAttributes({ textColor: value }),
-							label: __('Text Color', 'newspack-listings'),
+							onChange: value => setAttributes( { textColor: value } ),
+							label: __( 'Text Color', 'newspack-listings' ),
 						},
 						{
 							value: backgroundColor,
-							onChange: value =>
-								setAttributes({ backgroundColor: value }),
-							label: __('Background Color', 'newspack-listings'),
+							onChange: value => setAttributes( { backgroundColor: value } ),
+							label: __( 'Background Color', 'newspack-listings' ),
 						},
-					]}
+					] }
 				/>
-				<PanelBody title={__('Meta Settings', 'newspack-listings')}>
+				<PanelBody title={ __( 'Meta Settings', 'newspack-listings' ) }>
 					<PanelRow>
 						<ToggleControl
-							label={__('Show Author', 'newspack-listings')}
-							checked={showAuthor}
-							onChange={() =>
-								setAttributes({ showAuthor: !showAuthor })
-							}
+							label={ __( 'Show Author', 'newspack-listings' ) }
+							checked={ showAuthor }
+							onChange={ () => setAttributes( { showAuthor: ! showAuthor } ) }
 						/>
 					</PanelRow>
 					<PanelRow>
 						<ToggleControl
-							label={__('Show Category', 'newspack-listings')}
-							checked={showCategory}
-							onChange={() =>
-								setAttributes({ showCategory: !showCategory })
-							}
+							label={ __( 'Show Category', 'newspack-listings' ) }
+							checked={ showCategory }
+							onChange={ () => setAttributes( { showCategory: ! showCategory } ) }
 						/>
 					</PanelRow>
 					<PanelRow>
 						<ToggleControl
-							label={__('Show Tags', 'newspack-listings')}
-							checked={showTags}
-							onChange={() =>
-								setAttributes({ showTags: !showTags })
-							}
+							label={ __( 'Show Tags', 'newspack-listings' ) }
+							checked={ showTags }
+							onChange={ () => setAttributes( { showTags: ! showTags } ) }
 						/>
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
 			<div
-				className={classes.join(' ')}
-				style={{
+				className={ classes.join( ' ' ) }
+				style={ {
 					backgroundColor: backgroundColor || '#fff',
 					color: textColor || '#000',
-				}}
+				} }
 			>
-				{queryMode && error && (
-					<Notice
-						className="newspack-listings__error"
-						status="error"
-						isDismissible={false}
-					>
-						{error}
+				{ queryMode && error && (
+					<Notice className="newspack-listings__error" status="error" isDismissible={ false }>
+						{ error }
 					</Notice>
-				)}
+				) }
 				<InnerBlocks
-					allowedBlocks={[
-						'jetpack/map',
-						'newspack-listings/list-container',
-					]}
-					template={[['newspack-listings/list-container']]} // Start with an empty list only.
-					templateInsertUpdatesSelection={false}
-					renderAppender={() => null} // We want to discourage editors from adding blocks in this top-level wrapper, but we can't lock the template because we still need to be able to programmatically add or remove map blocks.
+					allowedBlocks={ [ 'jetpack/map', 'newspack-listings/list-container' ] }
+					template={ [ [ 'newspack-listings/list-container' ] ] } // Start with an empty list only.
+					templateInsertUpdatesSelection={ false }
+					renderAppender={ () => null } // We want to discourage editors from adding blocks in this top-level wrapper, but we can't lock the template because we still need to be able to programmatically add or remove map blocks.
 				/>
 				{
 					// If in query mode and while fetching posts.
@@ -771,33 +617,23 @@ const CuratedListEditorComponent = ({
 				}
 				{
 					// If in query mode, show the queried listings.
-					!isFetching &&
-						queryMode &&
-						queriedListings.map(renderQueriedListings)
+					! isFetching && queryMode && queriedListings.map( renderQueriedListings )
 				}
-				{!isFetching &&
-					queryMode &&
-					showLoadMore &&
-					queryOptions.maxItems < queriedListings.length && (
-						<Button
-							className="newspack-listings__load-more"
-							isPrimary
-						>
-							{loadMoreText}
-						</Button>
-					)}
+				{ ! isFetching && queryMode && showLoadMore && queryOptions.maxItems < queriedListings.length && (
+					<Button className="newspack-listings__load-more" isPrimary>
+						{ loadMoreText }
+					</Button>
+				) }
 			</div>
 		</div>
 	);
 };
 
-const mapStateToProps = (select, ownProps) => {
-	const { getBlocksByClientId, getSelectedBlockClientId } =
-		select('core/block-editor');
-	const { getBlockType } = select('core/blocks');
-	const innerBlocks =
-		getBlocksByClientId(ownProps.clientId)[0].innerBlocks || [];
-	const canUseMapBlock = !!getBlockType('jetpack/map'); // Check for existence of Jetpack Map block before enabling location-based features.
+const mapStateToProps = ( select, ownProps ) => {
+	const { getBlocksByClientId, getSelectedBlockClientId } = select( 'core/block-editor' );
+	const { getBlockType } = select( 'core/blocks' );
+	const innerBlocks = getBlocksByClientId( ownProps.clientId )[ 0 ].innerBlocks || [];
+	const canUseMapBlock = !! getBlockType( 'jetpack/map' ); // Check for existence of Jetpack Map block before enabling location-based features.
 
 	return {
 		canUseMapBlock,
@@ -807,8 +643,7 @@ const mapStateToProps = (select, ownProps) => {
 };
 
 const mapDispatchToProps = dispatch => {
-	const { insertBlocks, removeBlocks, selectBlock, updateBlockAttributes } =
-		dispatch('core/block-editor');
+	const { insertBlocks, removeBlocks, selectBlock, updateBlockAttributes } = dispatch( 'core/block-editor' );
 
 	return {
 		insertBlocks,
@@ -818,7 +653,4 @@ const mapDispatchToProps = dispatch => {
 	};
 };
 
-export const CuratedListEditor = compose([
-	withSelect(mapStateToProps),
-	withDispatch(mapDispatchToProps),
-])(CuratedListEditorComponent);
+export const CuratedListEditor = compose( [ withSelect( mapStateToProps ), withDispatch( mapDispatchToProps ) ] )( CuratedListEditorComponent );

--- a/src/blocks/curated-list/index.js
+++ b/src/blocks/curated-list/index.js
@@ -16,6 +16,7 @@ const { attributes, category, name } = metadata;
 
 export const registerCuratedListBlock = () => {
 	registerBlockType( name, {
+		apiVersion: 3,
 		title: __( 'Curated List', 'newspack-listings' ),
 		icon: {
 			src: <List />,

--- a/src/blocks/curated-list/view.php
+++ b/src/blocks/curated-list/view.php
@@ -15,17 +15,10 @@ use Newspack_Listings\Utils;
  * Dynamic block registration.
  */
 function register_block() {
-	// Listings block attributes.
-	$block_json = json_decode(
-		file_get_contents( __DIR__ . '/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		true
-	);
-
 	// Register Curated List block.
 	register_block_type(
-		$block_json['name'],
+		__DIR__,
 		[
-			'attributes'      => $block_json['attributes'],
 			'render_callback' => __NAMESPACE__ . '\render_block',
 		]
 	);

--- a/src/blocks/event-dates/block.json
+++ b/src/blocks/event-dates/block.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "newspack-listings/event-dates",
 	"category": "newspack",
 	"attributes": {

--- a/src/blocks/event-dates/edit.js
+++ b/src/blocks/event-dates/edit.js
@@ -48,56 +48,26 @@ export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 			</InspectorControls>
 			<div { ...blockProps }>
 				<div className={ classes.join( ' ' ) }>
-				<div className="newspack-listings__event-dates-controls">
-					<BaseControl
-						id={ `event-start-date-${ clientId }` }
-						label={ sprintf(
-							// translators: %1$s: start date/time label, %2$s: start date/time label.
-							__( 'Event %1$s %2$s', 'newspack-listings' ),
-							showEnd ? __( 'Start', 'newspack-listings' ) : '',
-							showTime ? __( 'Time', 'newspack-listings' ) : __( 'Date', 'newspack-listings' )
-						) }
-					>
-						<DateTimePicker
-							currentDate={ startDate ? new Date( startDate ) : null }
-							is12Hour={ true }
-							onChange={ value => {
-								if (
-									! value || // If clearing the value.
-									! endDate || // If there isn't an end date to compare with.
-									( endDate && 0 <= new Date( endDate ) - new Date( value ) ) // If there is an end date, and it's after the selected start date.
-								) {
-									return setAttributes( { startDate: value } );
-								}
-
-								createNotice( 'warning', __( 'Event end must be after event start.', 'newspack-listings' ), {
-									id: 'newspack-listings__date-error',
-									isDismissible: true,
-									type: 'default',
-								} );
-							} }
-						/>
-						{ ! showTime && startDate && (
-							<Button isLink onClick={ () => setAttributes( { startDate: '' } ) }>
-								{ __( 'Reset', 'newspack-listings' ) }
-							</Button>
-						) }
-					</BaseControl>
-					{ showEnd && (
+					<div className="newspack-listings__event-dates-controls">
 						<BaseControl
-							id={ `event-end-date-${ clientId }` }
+							id={ `event-start-date-${ clientId }` }
 							label={ sprintf(
-								// translators: %s: end date/time label.
-								__( 'Event End %s', 'newspack-listings' ),
+								// translators: %1$s: start date/time label, %2$s: start date/time label.
+								__( 'Event %1$s %2$s', 'newspack-listings' ),
+								showEnd ? __( 'Start', 'newspack-listings' ) : '',
 								showTime ? __( 'Time', 'newspack-listings' ) : __( 'Date', 'newspack-listings' )
 							) }
 						>
 							<DateTimePicker
-								currentDate={ endDate ? new Date( endDate ) : null }
+								currentDate={ startDate ? new Date( startDate ) : null }
 								is12Hour={ true }
 								onChange={ value => {
-									if ( ! value || ! startDate || ( startDate && 0 <= new Date( value ) - new Date( startDate ) ) ) {
-										return setAttributes( { endDate: value } );
+									if (
+										! value || // If clearing the value.
+										! endDate || // If there isn't an end date to compare with.
+										( endDate && 0 <= new Date( endDate ) - new Date( value ) ) // If there is an end date, and it's after the selected start date.
+									) {
+										return setAttributes( { startDate: value } );
 									}
 
 									createNotice( 'warning', __( 'Event end must be after event start.', 'newspack-listings' ), {
@@ -107,15 +77,45 @@ export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 									} );
 								} }
 							/>
-							{ ! showTime && endDate && (
-								<Button isLink onClick={ () => setAttributes( { endDate: '' } ) }>
+							{ ! showTime && startDate && (
+								<Button isLink onClick={ () => setAttributes( { startDate: '' } ) }>
 									{ __( 'Reset', 'newspack-listings' ) }
 								</Button>
 							) }
 						</BaseControl>
-					) }
+						{ showEnd && (
+							<BaseControl
+								id={ `event-end-date-${ clientId }` }
+								label={ sprintf(
+									// translators: %s: end date/time label.
+									__( 'Event End %s', 'newspack-listings' ),
+									showTime ? __( 'Time', 'newspack-listings' ) : __( 'Date', 'newspack-listings' )
+								) }
+							>
+								<DateTimePicker
+									currentDate={ endDate ? new Date( endDate ) : null }
+									is12Hour={ true }
+									onChange={ value => {
+										if ( ! value || ! startDate || ( startDate && 0 <= new Date( value ) - new Date( startDate ) ) ) {
+											return setAttributes( { endDate: value } );
+										}
+
+										createNotice( 'warning', __( 'Event end must be after event start.', 'newspack-listings' ), {
+											id: 'newspack-listings__date-error',
+											isDismissible: true,
+											type: 'default',
+										} );
+									} }
+								/>
+								{ ! showTime && endDate && (
+									<Button isLink onClick={ () => setAttributes( { endDate: '' } ) }>
+										{ __( 'Reset', 'newspack-listings' ) }
+									</Button>
+								) }
+							</BaseControl>
+						) }
+					</div>
 				</div>
-			</div>
 			</div>
 		</>
 	);

--- a/src/blocks/event-dates/edit.js
+++ b/src/blocks/event-dates/edit.js
@@ -18,7 +18,7 @@ export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 	const blockProps = useBlockProps();
 
 	return (
-		<div { ...blockProps }>
+		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Event Dates Settings' ) }>
 					<PanelRow>
@@ -46,8 +46,8 @@ export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
-
-			<div className={ classes.join( ' ' ) }>
+			<div { ...blockProps }>
+				<div className={ classes.join( ' ' ) }>
 				<div className="newspack-listings__event-dates-controls">
 					<BaseControl
 						id={ `event-start-date-${ clientId }` }
@@ -116,6 +116,7 @@ export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 					) }
 				</div>
 			</div>
-		</div>
+			</div>
+		</>
 	);
 };

--- a/src/blocks/event-dates/edit.js
+++ b/src/blocks/event-dates/edit.js
@@ -2,119 +2,168 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/block-editor';
-import { BaseControl, Button, DateTimePicker, PanelBody, PanelRow, ToggleControl } from '@wordpress/components';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	BaseControl,
+	Button,
+	DateTimePicker,
+	PanelBody,
+	PanelRow,
+	ToggleControl,
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
 
-export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
+export const EventDatesEditor = ({ attributes, clientId, setAttributes }) => {
 	const { endDate, showEnd, showTime, startDate } = attributes;
-	const { createNotice } = useDispatch( 'core/notices' );
-	const classes = [ 'newspack-listings__event-dates' ];
+	const { createNotice } = useDispatch('core/notices');
+	const classes = ['newspack-listings__event-dates'];
 
-	if ( ! showTime ) {
-		classes.push( 'hide-time' );
+	if (!showTime) {
+		classes.push('hide-time');
 	}
 
+	const blockProps = useBlockProps();
+
 	return (
-		<Fragment>
+		<div {...blockProps}>
 			<InspectorControls>
-				<PanelBody title={ __( 'Event Dates Settings' ) }>
+				<PanelBody title={__('Event Dates Settings')}>
 					<PanelRow>
 						<ToggleControl
 							className="newspack-listings__event-time-toggle"
-							label={ __( 'Show Times', 'newspack-listings' ) }
-							checked={ showTime }
-							onChange={ () => setAttributes( { showTime: ! showTime } ) }
+							label={__('Show Times', 'newspack-listings')}
+							checked={showTime}
+							onChange={() =>
+								setAttributes({ showTime: !showTime })
+							}
 						/>
 					</PanelRow>
 					<PanelRow>
 						<ToggleControl
 							className="newspack-listings__event-time-toggle"
-							label={ sprintf(
+							label={sprintf(
 								// translators: %s: end date/time label.
-								__( 'Show End %s', 'newspack-listings' ),
-								showTime ? __( 'Time', 'newspack-listings' ) : __( 'Date', 'newspack-listings' )
-							) }
-							checked={ showEnd }
-							onChange={ () => {
-								setAttributes( { showEnd: ! showEnd } );
-								setAttributes( { endDate: '' } );
-							} }
+								__('Show End %s', 'newspack-listings'),
+								showTime
+									? __('Time', 'newspack-listings')
+									: __('Date', 'newspack-listings')
+							)}
+							checked={showEnd}
+							onChange={() => {
+								setAttributes({ showEnd: !showEnd });
+								setAttributes({ endDate: '' });
+							}}
 						/>
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
 
-			<div className={ classes.join( ' ' ) }>
+			<div className={classes.join(' ')}>
 				<div className="newspack-listings__event-dates-controls">
 					<BaseControl
-						id={ `event-start-date-${ clientId }` }
-						label={ sprintf(
+						id={`event-start-date-${clientId}`}
+						label={sprintf(
 							// translators: %1$s: start date/time label, %2$s: start date/time label.
-							__( 'Event %1$s %2$s', 'newspack-listings' ),
-							showEnd ? __( 'Start', 'newspack-listings' ) : '',
-							showTime ? __( 'Time', 'newspack-listings' ) : __( 'Date', 'newspack-listings' )
-						) }
+							__('Event %1$s %2$s', 'newspack-listings'),
+							showEnd ? __('Start', 'newspack-listings') : '',
+							showTime
+								? __('Time', 'newspack-listings')
+								: __('Date', 'newspack-listings')
+						)}
 					>
 						<DateTimePicker
-							currentDate={ startDate ? new Date( startDate ) : null }
-							is12Hour={ true }
-							onChange={ value => {
+							currentDate={startDate ? new Date(startDate) : null}
+							is12Hour={true}
+							onChange={value => {
 								if (
-									! value || // If clearing the value.
-									! endDate || // If there isn't an end date to compare with.
-									( endDate && 0 <= new Date( endDate ) - new Date( value ) ) // If there is an end date, and it's after the selected start date.
+									!value || // If clearing the value.
+									!endDate || // If there isn't an end date to compare with.
+									(endDate &&
+										0 <=
+											new Date(endDate) - new Date(value)) // If there is an end date, and it's after the selected start date.
 								) {
-									return setAttributes( { startDate: value } );
+									return setAttributes({ startDate: value });
 								}
 
-								createNotice( 'warning', __( 'Event end must be after event start.', 'newspack-listings' ), {
-									id: 'newspack-listings__date-error',
-									isDismissible: true,
-									type: 'default',
-								} );
-							} }
-						/>
-						{ ! showTime && startDate && (
-							<Button isLink onClick={ () => setAttributes( { startDate: '' } ) }>
-								{ __( 'Reset', 'newspack-listings' ) }
-							</Button>
-						) }
-					</BaseControl>
-					{ showEnd && (
-						<BaseControl
-							id={ `event-end-date-${ clientId }` }
-							label={ sprintf(
-								// translators: %s: end date/time label.
-								__( 'Event End %s', 'newspack-listings' ),
-								showTime ? __( 'Time', 'newspack-listings' ) : __( 'Date', 'newspack-listings' )
-							) }
-						>
-							<DateTimePicker
-								currentDate={ endDate ? new Date( endDate ) : null }
-								is12Hour={ true }
-								onChange={ value => {
-									if ( ! value || ! startDate || ( startDate && 0 <= new Date( value ) - new Date( startDate ) ) ) {
-										return setAttributes( { endDate: value } );
-									}
-
-									createNotice( 'warning', __( 'Event end must be after event start.', 'newspack-listings' ), {
+								createNotice(
+									'warning',
+									__(
+										'Event end must be after event start.',
+										'newspack-listings'
+									),
+									{
 										id: 'newspack-listings__date-error',
 										isDismissible: true,
 										type: 'default',
-									} );
-								} }
+									}
+								);
+							}}
+						/>
+						{!showTime && startDate && (
+							<Button
+								isLink
+								onClick={() => setAttributes({ startDate: '' })}
+							>
+								{__('Reset', 'newspack-listings')}
+							</Button>
+						)}
+					</BaseControl>
+					{showEnd && (
+						<BaseControl
+							id={`event-end-date-${clientId}`}
+							label={sprintf(
+								// translators: %s: end date/time label.
+								__('Event End %s', 'newspack-listings'),
+								showTime
+									? __('Time', 'newspack-listings')
+									: __('Date', 'newspack-listings')
+							)}
+						>
+							<DateTimePicker
+								currentDate={endDate ? new Date(endDate) : null}
+								is12Hour={true}
+								onChange={value => {
+									if (
+										!value ||
+										!startDate ||
+										(startDate &&
+											0 <=
+												new Date(value) -
+													new Date(startDate))
+									) {
+										return setAttributes({
+											endDate: value,
+										});
+									}
+
+									createNotice(
+										'warning',
+										__(
+											'Event end must be after event start.',
+											'newspack-listings'
+										),
+										{
+											id: 'newspack-listings__date-error',
+											isDismissible: true,
+											type: 'default',
+										}
+									);
+								}}
 							/>
-							{ ! showTime && endDate && (
-								<Button isLink onClick={ () => setAttributes( { endDate: '' } ) }>
-									{ __( 'Reset', 'newspack-listings' ) }
+							{!showTime && endDate && (
+								<Button
+									isLink
+									onClick={() =>
+										setAttributes({ endDate: '' })
+									}
+								>
+									{__('Reset', 'newspack-listings')}
 								</Button>
-							) }
+							)}
 						</BaseControl>
-					) }
+					)}
 				</div>
 			</div>
-		</Fragment>
+		</div>
 	);
 };

--- a/src/blocks/event-dates/edit.js
+++ b/src/blocks/event-dates/edit.js
@@ -3,165 +3,117 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import {
-	BaseControl,
-	Button,
-	DateTimePicker,
-	PanelBody,
-	PanelRow,
-	ToggleControl,
-} from '@wordpress/components';
+import { BaseControl, Button, DateTimePicker, PanelBody, PanelRow, ToggleControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 
-export const EventDatesEditor = ({ attributes, clientId, setAttributes }) => {
+export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 	const { endDate, showEnd, showTime, startDate } = attributes;
-	const { createNotice } = useDispatch('core/notices');
-	const classes = ['newspack-listings__event-dates'];
+	const { createNotice } = useDispatch( 'core/notices' );
+	const classes = [ 'newspack-listings__event-dates' ];
 
-	if (!showTime) {
-		classes.push('hide-time');
+	if ( ! showTime ) {
+		classes.push( 'hide-time' );
 	}
 
 	const blockProps = useBlockProps();
 
 	return (
-		<div {...blockProps}>
+		<div { ...blockProps }>
 			<InspectorControls>
-				<PanelBody title={__('Event Dates Settings')}>
+				<PanelBody title={ __( 'Event Dates Settings' ) }>
 					<PanelRow>
 						<ToggleControl
 							className="newspack-listings__event-time-toggle"
-							label={__('Show Times', 'newspack-listings')}
-							checked={showTime}
-							onChange={() =>
-								setAttributes({ showTime: !showTime })
-							}
+							label={ __( 'Show Times', 'newspack-listings' ) }
+							checked={ showTime }
+							onChange={ () => setAttributes( { showTime: ! showTime } ) }
 						/>
 					</PanelRow>
 					<PanelRow>
 						<ToggleControl
 							className="newspack-listings__event-time-toggle"
-							label={sprintf(
+							label={ sprintf(
 								// translators: %s: end date/time label.
-								__('Show End %s', 'newspack-listings'),
-								showTime
-									? __('Time', 'newspack-listings')
-									: __('Date', 'newspack-listings')
-							)}
-							checked={showEnd}
-							onChange={() => {
-								setAttributes({ showEnd: !showEnd });
-								setAttributes({ endDate: '' });
-							}}
+								__( 'Show End %s', 'newspack-listings' ),
+								showTime ? __( 'Time', 'newspack-listings' ) : __( 'Date', 'newspack-listings' )
+							) }
+							checked={ showEnd }
+							onChange={ () => {
+								setAttributes( { showEnd: ! showEnd } );
+								setAttributes( { endDate: '' } );
+							} }
 						/>
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
 
-			<div className={classes.join(' ')}>
+			<div className={ classes.join( ' ' ) }>
 				<div className="newspack-listings__event-dates-controls">
 					<BaseControl
-						id={`event-start-date-${clientId}`}
-						label={sprintf(
+						id={ `event-start-date-${ clientId }` }
+						label={ sprintf(
 							// translators: %1$s: start date/time label, %2$s: start date/time label.
-							__('Event %1$s %2$s', 'newspack-listings'),
-							showEnd ? __('Start', 'newspack-listings') : '',
-							showTime
-								? __('Time', 'newspack-listings')
-								: __('Date', 'newspack-listings')
-						)}
+							__( 'Event %1$s %2$s', 'newspack-listings' ),
+							showEnd ? __( 'Start', 'newspack-listings' ) : '',
+							showTime ? __( 'Time', 'newspack-listings' ) : __( 'Date', 'newspack-listings' )
+						) }
 					>
 						<DateTimePicker
-							currentDate={startDate ? new Date(startDate) : null}
-							is12Hour={true}
-							onChange={value => {
+							currentDate={ startDate ? new Date( startDate ) : null }
+							is12Hour={ true }
+							onChange={ value => {
 								if (
-									!value || // If clearing the value.
-									!endDate || // If there isn't an end date to compare with.
-									(endDate &&
-										0 <=
-											new Date(endDate) - new Date(value)) // If there is an end date, and it's after the selected start date.
+									! value || // If clearing the value.
+									! endDate || // If there isn't an end date to compare with.
+									( endDate && 0 <= new Date( endDate ) - new Date( value ) ) // If there is an end date, and it's after the selected start date.
 								) {
-									return setAttributes({ startDate: value });
+									return setAttributes( { startDate: value } );
 								}
 
-								createNotice(
-									'warning',
-									__(
-										'Event end must be after event start.',
-										'newspack-listings'
-									),
-									{
+								createNotice( 'warning', __( 'Event end must be after event start.', 'newspack-listings' ), {
+									id: 'newspack-listings__date-error',
+									isDismissible: true,
+									type: 'default',
+								} );
+							} }
+						/>
+						{ ! showTime && startDate && (
+							<Button isLink onClick={ () => setAttributes( { startDate: '' } ) }>
+								{ __( 'Reset', 'newspack-listings' ) }
+							</Button>
+						) }
+					</BaseControl>
+					{ showEnd && (
+						<BaseControl
+							id={ `event-end-date-${ clientId }` }
+							label={ sprintf(
+								// translators: %s: end date/time label.
+								__( 'Event End %s', 'newspack-listings' ),
+								showTime ? __( 'Time', 'newspack-listings' ) : __( 'Date', 'newspack-listings' )
+							) }
+						>
+							<DateTimePicker
+								currentDate={ endDate ? new Date( endDate ) : null }
+								is12Hour={ true }
+								onChange={ value => {
+									if ( ! value || ! startDate || ( startDate && 0 <= new Date( value ) - new Date( startDate ) ) ) {
+										return setAttributes( { endDate: value } );
+									}
+
+									createNotice( 'warning', __( 'Event end must be after event start.', 'newspack-listings' ), {
 										id: 'newspack-listings__date-error',
 										isDismissible: true,
 										type: 'default',
-									}
-								);
-							}}
-						/>
-						{!showTime && startDate && (
-							<Button
-								isLink
-								onClick={() => setAttributes({ startDate: '' })}
-							>
-								{__('Reset', 'newspack-listings')}
-							</Button>
-						)}
-					</BaseControl>
-					{showEnd && (
-						<BaseControl
-							id={`event-end-date-${clientId}`}
-							label={sprintf(
-								// translators: %s: end date/time label.
-								__('Event End %s', 'newspack-listings'),
-								showTime
-									? __('Time', 'newspack-listings')
-									: __('Date', 'newspack-listings')
-							)}
-						>
-							<DateTimePicker
-								currentDate={endDate ? new Date(endDate) : null}
-								is12Hour={true}
-								onChange={value => {
-									if (
-										!value ||
-										!startDate ||
-										(startDate &&
-											0 <=
-												new Date(value) -
-													new Date(startDate))
-									) {
-										return setAttributes({
-											endDate: value,
-										});
-									}
-
-									createNotice(
-										'warning',
-										__(
-											'Event end must be after event start.',
-											'newspack-listings'
-										),
-										{
-											id: 'newspack-listings__date-error',
-											isDismissible: true,
-											type: 'default',
-										}
-									);
-								}}
+									} );
+								} }
 							/>
-							{!showTime && endDate && (
-								<Button
-									isLink
-									onClick={() =>
-										setAttributes({ endDate: '' })
-									}
-								>
-									{__('Reset', 'newspack-listings')}
+							{ ! showTime && endDate && (
+								<Button isLink onClick={ () => setAttributes( { endDate: '' } ) }>
+									{ __( 'Reset', 'newspack-listings' ) }
 								</Button>
-							)}
+							) }
 						</BaseControl>
-					)}
+					) }
 				</div>
 			</div>
 		</div>

--- a/src/blocks/event-dates/index.js
+++ b/src/blocks/event-dates/index.js
@@ -14,6 +14,7 @@ const { attributes, category, name } = metadata;
 
 export const registerEventDatesBlock = () => {
 	registerBlockType( name, {
+		apiVersion: 3,
 		title: __( 'Event Dates', 'newspack-listings' ),
 		icon: {
 			src: calendar,

--- a/src/blocks/event-dates/view.php
+++ b/src/blocks/event-dates/view.php
@@ -14,17 +14,9 @@ use Newspack_Listings\Utils;
  * Dynamic block registration.
  */
 function register_block() {
-	// Block attributes.
-	$block_json = json_decode(
-		file_get_contents( __DIR__ . '/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		true
-	);
-
-	// Register Evend Dates block.
 	register_block_type(
-		$block_json['name'],
+		__DIR__,
 		[
-			'attributes'      => $block_json['attributes'],
 			'render_callback' => __NAMESPACE__ . '\render_block',
 		]
 	);

--- a/src/blocks/list-container/edit.js
+++ b/src/blocks/list-container/edit.js
@@ -27,58 +27,58 @@ const ListContainerEditorComponent = ( { attributes, clientId, innerBlocks } ) =
 			</InspectorControls>
 			<div { ...blockProps }>
 				{ ! queryMode && innerBlocks && 0 === innerBlocks.length && (
-				<Notice className="newspack-listings__info" status="info" isDismissible={ false }>
-					{ __( 'This list is empty. Click the [+] button to add some listings.' ) }
-				</Notice>
-			) }
-			{ showSortUi && (
-				<div className="newspack-listings__sort-ui">
-					<section>
-						<label className="newspack-listings__sort-ui-label" htmlFor={ `newspack-listings__sort-by-${ clientId }` }>
-							{ __( 'Sort by:', 'newspack-listings' ) }
-						</label>
-						<select
-							disabled // Just a dummy component for demo display.
-							className="newspack-listings__sort-select-control"
-							id={ `newspack-listings__sort-by-${ clientId }` }
-						>
-							<option value="" selected>
-								{ __( 'Sort by', 'newspack-listings' ) }
-							</option>
-						</select>
-					</section>
+					<Notice className="newspack-listings__info" status="info" isDismissible={ false }>
+						{ __( 'This list is empty. Click the [+] button to add some listings.' ) }
+					</Notice>
+				) }
+				{ showSortUi && (
+					<div className="newspack-listings__sort-ui">
+						<section>
+							<label className="newspack-listings__sort-ui-label" htmlFor={ `newspack-listings__sort-by-${ clientId }` }>
+								{ __( 'Sort by:', 'newspack-listings' ) }
+							</label>
+							<select
+								disabled // Just a dummy component for demo display.
+								className="newspack-listings__sort-select-control"
+								id={ `newspack-listings__sort-by-${ clientId }` }
+							>
+								<option value="" selected>
+									{ __( 'Sort by', 'newspack-listings' ) }
+								</option>
+							</select>
+						</section>
 
-					<section>
-						<label className="newspack-listings__sort-ui-label" htmlFor={ `sort-buttons-${ clientId }` }>
-							{ __( 'Sort order:', 'newspack-listings' ) }
-						</label>
+						<section>
+							<label className="newspack-listings__sort-ui-label" htmlFor={ `sort-buttons-${ clientId }` }>
+								{ __( 'Sort order:', 'newspack-listings' ) }
+							</label>
 
-						<div id={ `sort-buttons-${ clientId }` }>
-							<input
-								disabled
-								id={ `sort-ascending-${ clientId }` }
-								type="radio"
-								name="newspack-listings__sort-order"
-								value="ASC"
-								checked={ queryMode && order === 'ASC' }
-							/>
-							<label htmlFor={ `sort-ascending-${ clientId }` }>{ __( 'Ascending', 'newspack-listings' ) }</label>
-						</div>
+							<div id={ `sort-buttons-${ clientId }` }>
+								<input
+									disabled
+									id={ `sort-ascending-${ clientId }` }
+									type="radio"
+									name="newspack-listings__sort-order"
+									value="ASC"
+									checked={ queryMode && order === 'ASC' }
+								/>
+								<label htmlFor={ `sort-ascending-${ clientId }` }>{ __( 'Ascending', 'newspack-listings' ) }</label>
+							</div>
 
-						<div>
-							<input
-								disabled
-								id={ `sort-descending-${ clientId }` }
-								type="radio"
-								name="newspack-listings__sort-order"
-								value="DESC"
-								checked={ queryMode && order === 'DESC' }
-							/>
-							<label htmlFor={ `sort-descending-${ clientId }` }>{ __( 'Descending', 'newspack-listings' ) }</label>
-						</div>
-					</section>
-				</div>
-			) }
+							<div>
+								<input
+									disabled
+									id={ `sort-descending-${ clientId }` }
+									type="radio"
+									name="newspack-listings__sort-order"
+									value="DESC"
+									checked={ queryMode && order === 'DESC' }
+								/>
+								<label htmlFor={ `sort-descending-${ clientId }` }>{ __( 'Descending', 'newspack-listings' ) }</label>
+							</div>
+						</section>
+					</div>
+				) }
 				<InnerBlocks
 					allowedBlocks={ [
 						'newspack-listings/event',

--- a/src/blocks/list-container/edit.js
+++ b/src/blocks/list-container/edit.js
@@ -19,13 +19,14 @@ const ListContainerEditorComponent = ( { attributes, clientId, innerBlocks } ) =
 	}
 
 	return (
-		<div { ...blockProps }>
+		<>
 			<InspectorControls>
 				<PanelRow className="newspack-listings__list-container-spinner">
 					<Spinner />
 				</PanelRow>
 			</InspectorControls>
-			{ ! queryMode && innerBlocks && 0 === innerBlocks.length && (
+			<div { ...blockProps }>
+				{ ! queryMode && innerBlocks && 0 === innerBlocks.length && (
 				<Notice className="newspack-listings__info" status="info" isDismissible={ false }>
 					{ __( 'This list is empty. Click the [+] button to add some listings.' ) }
 				</Notice>
@@ -78,16 +79,17 @@ const ListContainerEditorComponent = ( { attributes, clientId, innerBlocks } ) =
 					</section>
 				</div>
 			) }
-			<InnerBlocks
-				allowedBlocks={ [
-					'newspack-listings/event',
-					'newspack-listings/generic',
-					'newspack-listings/marketplace',
-					'newspack-listings/place',
-				] }
-				renderAppender={ () => ( queryMode ? null : <InnerBlocks.ButtonBlockAppender /> ) }
-			/>
-		</div>
+				<InnerBlocks
+					allowedBlocks={ [
+						'newspack-listings/event',
+						'newspack-listings/generic',
+						'newspack-listings/marketplace',
+						'newspack-listings/place',
+					] }
+					renderAppender={ () => ( queryMode ? null : <InnerBlocks.ButtonBlockAppender /> ) }
+				/>
+			</div>
+		</>
 	);
 };
 

--- a/src/blocks/list-container/edit.js
+++ b/src/blocks/list-container/edit.js
@@ -2,96 +2,125 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InnerBlocks, InspectorControls } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	InspectorControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { Notice, PanelRow, Spinner } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 
-const ListContainerEditorComponent = ( { attributes, clientId, innerBlocks } ) => {
+const ListContainerEditorComponent = ({
+	attributes,
+	clientId,
+	innerBlocks,
+}) => {
 	const { queryMode, queryOptions, showSortUi } = attributes;
 	const { order } = queryOptions;
+	const blockProps = useBlockProps({
+		className: 'newspack-listings__list-container',
+	});
 
-	if ( queryMode && ! showSortUi ) {
-		return null;
+	if (queryMode && !showSortUi) {
+		return <div {...blockProps} style={{ display: 'none' }} />;
 	}
 
 	return (
-		<div className="newspack-listings__list-container">
+		<div {...blockProps}>
 			<InspectorControls>
 				<PanelRow className="newspack-listings__list-container-spinner">
 					<Spinner />
 				</PanelRow>
 			</InspectorControls>
-			{ ! queryMode && innerBlocks && 0 === innerBlocks.length && (
-				<Notice className="newspack-listings__info" status="info" isDismissible={ false }>
-					{ __( 'This list is empty. Click the [+] button to add some listings.' ) }
+			{!queryMode && innerBlocks && 0 === innerBlocks.length && (
+				<Notice
+					className="newspack-listings__info"
+					status="info"
+					isDismissible={false}
+				>
+					{__(
+						'This list is empty. Click the [+] button to add some listings.'
+					)}
 				</Notice>
-			) }
-			{ showSortUi && (
+			)}
+			{showSortUi && (
 				<div className="newspack-listings__sort-ui">
 					<section>
-						<label className="newspack-listings__sort-ui-label" htmlFor={ `newspack-listings__sort-by-${ clientId }` }>
-							{ __( 'Sort by:', 'newspack-listings' ) }
+						<label
+							className="newspack-listings__sort-ui-label"
+							htmlFor={`newspack-listings__sort-by-${clientId}`}
+						>
+							{__('Sort by:', 'newspack-listings')}
 						</label>
 						<select
 							disabled // Just a dummy component for demo display.
 							className="newspack-listings__sort-select-control"
-							id={ `newspack-listings__sort-by-${ clientId }` }
+							id={`newspack-listings__sort-by-${clientId}`}
 						>
 							<option value="" selected>
-								{ __( 'Sort by', 'newspack-listings' ) }
+								{__('Sort by', 'newspack-listings')}
 							</option>
 						</select>
 					</section>
 
 					<section>
-						<label className="newspack-listings__sort-ui-label" htmlFor={ `sort-buttons-${ clientId }` }>
-							{ __( 'Sort order:', 'newspack-listings' ) }
+						<label
+							className="newspack-listings__sort-ui-label"
+							htmlFor={`sort-buttons-${clientId}`}
+						>
+							{__('Sort order:', 'newspack-listings')}
 						</label>
 
-						<div id={ `sort-buttons-${ clientId }` }>
+						<div id={`sort-buttons-${clientId}`}>
 							<input
 								disabled
-								id={ `sort-ascending-${ clientId }` }
+								id={`sort-ascending-${clientId}`}
 								type="radio"
 								name="newspack-listings__sort-order"
 								value="ASC"
-								checked={ queryMode && order === 'ASC' }
+								checked={queryMode && order === 'ASC'}
 							/>
-							<label htmlFor={ `sort-ascending-${ clientId }` }>{ __( 'Ascending', 'newspack-listings' ) }</label>
+							<label htmlFor={`sort-ascending-${clientId}`}>
+								{__('Ascending', 'newspack-listings')}
+							</label>
 						</div>
 
 						<div>
 							<input
 								disabled
-								id={ `sort-descending-${ clientId }` }
+								id={`sort-descending-${clientId}`}
 								type="radio"
 								name="newspack-listings__sort-order"
 								value="DESC"
-								checked={ queryMode && order === 'DESC' }
+								checked={queryMode && order === 'DESC'}
 							/>
-							<label htmlFor={ `sort-descending-${ clientId }` }>{ __( 'Descending', 'newspack-listings' ) }</label>
+							<label htmlFor={`sort-descending-${clientId}`}>
+								{__('Descending', 'newspack-listings')}
+							</label>
 						</div>
 					</section>
 				</div>
-			) }
+			)}
 			<InnerBlocks
-				allowedBlocks={ [
+				allowedBlocks={[
 					'newspack-listings/event',
 					'newspack-listings/generic',
 					'newspack-listings/marketplace',
 					'newspack-listings/place',
-				] }
-				renderAppender={ () => ( queryMode ? null : <InnerBlocks.ButtonBlockAppender /> ) }
+				]}
+				renderAppender={() =>
+					queryMode ? null : <InnerBlocks.ButtonBlockAppender />
+				}
 			/>
 		</div>
 	);
 };
 
-const mapStateToProps = ( select, ownProps ) => {
+const mapStateToProps = (select, ownProps) => {
 	const { clientId } = ownProps;
-	const { getBlock } = select( 'core/block-editor' );
-	const innerBlocks = getBlock( clientId ).innerBlocks || [];
+	const { getBlock } = select('core/block-editor');
+	const innerBlocks = getBlock(clientId).innerBlocks || [];
 
 	return {
 		innerBlocks,
@@ -99,7 +128,8 @@ const mapStateToProps = ( select, ownProps ) => {
 };
 
 const mapDispatchToProps = dispatch => {
-	const { insertBlock, removeBlocks, updateBlockAttributes } = dispatch( 'core/block-editor' );
+	const { insertBlock, removeBlocks, updateBlockAttributes } =
+		dispatch('core/block-editor');
 
 	return {
 		insertBlock,
@@ -108,4 +138,7 @@ const mapDispatchToProps = dispatch => {
 	};
 };
 
-export const ListContainerEditor = compose( [ withSelect( mapStateToProps ), withDispatch( mapDispatchToProps ) ] )( ListContainerEditorComponent );
+export const ListContainerEditor = compose([
+	withSelect(mapStateToProps),
+	withDispatch(mapDispatchToProps),
+])(ListContainerEditorComponent);

--- a/src/blocks/list-container/edit.js
+++ b/src/blocks/list-container/edit.js
@@ -2,125 +2,99 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	InnerBlocks,
-	InspectorControls,
-	useBlockProps,
-} from '@wordpress/block-editor';
+import { InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { Notice, PanelRow, Spinner } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 
-const ListContainerEditorComponent = ({
-	attributes,
-	clientId,
-	innerBlocks,
-}) => {
+const ListContainerEditorComponent = ( { attributes, clientId, innerBlocks } ) => {
 	const { queryMode, queryOptions, showSortUi } = attributes;
 	const { order } = queryOptions;
-	const blockProps = useBlockProps({
+	const blockProps = useBlockProps( {
 		className: 'newspack-listings__list-container',
-	});
+	} );
 
-	if (queryMode && !showSortUi) {
-		return <div {...blockProps} style={{ display: 'none' }} />;
+	if ( queryMode && ! showSortUi ) {
+		return <div { ...blockProps } style={ { display: 'none' } } />;
 	}
 
 	return (
-		<div {...blockProps}>
+		<div { ...blockProps }>
 			<InspectorControls>
 				<PanelRow className="newspack-listings__list-container-spinner">
 					<Spinner />
 				</PanelRow>
 			</InspectorControls>
-			{!queryMode && innerBlocks && 0 === innerBlocks.length && (
-				<Notice
-					className="newspack-listings__info"
-					status="info"
-					isDismissible={false}
-				>
-					{__(
-						'This list is empty. Click the [+] button to add some listings.'
-					)}
+			{ ! queryMode && innerBlocks && 0 === innerBlocks.length && (
+				<Notice className="newspack-listings__info" status="info" isDismissible={ false }>
+					{ __( 'This list is empty. Click the [+] button to add some listings.' ) }
 				</Notice>
-			)}
-			{showSortUi && (
+			) }
+			{ showSortUi && (
 				<div className="newspack-listings__sort-ui">
 					<section>
-						<label
-							className="newspack-listings__sort-ui-label"
-							htmlFor={`newspack-listings__sort-by-${clientId}`}
-						>
-							{__('Sort by:', 'newspack-listings')}
+						<label className="newspack-listings__sort-ui-label" htmlFor={ `newspack-listings__sort-by-${ clientId }` }>
+							{ __( 'Sort by:', 'newspack-listings' ) }
 						</label>
 						<select
 							disabled // Just a dummy component for demo display.
 							className="newspack-listings__sort-select-control"
-							id={`newspack-listings__sort-by-${clientId}`}
+							id={ `newspack-listings__sort-by-${ clientId }` }
 						>
 							<option value="" selected>
-								{__('Sort by', 'newspack-listings')}
+								{ __( 'Sort by', 'newspack-listings' ) }
 							</option>
 						</select>
 					</section>
 
 					<section>
-						<label
-							className="newspack-listings__sort-ui-label"
-							htmlFor={`sort-buttons-${clientId}`}
-						>
-							{__('Sort order:', 'newspack-listings')}
+						<label className="newspack-listings__sort-ui-label" htmlFor={ `sort-buttons-${ clientId }` }>
+							{ __( 'Sort order:', 'newspack-listings' ) }
 						</label>
 
-						<div id={`sort-buttons-${clientId}`}>
+						<div id={ `sort-buttons-${ clientId }` }>
 							<input
 								disabled
-								id={`sort-ascending-${clientId}`}
+								id={ `sort-ascending-${ clientId }` }
 								type="radio"
 								name="newspack-listings__sort-order"
 								value="ASC"
-								checked={queryMode && order === 'ASC'}
+								checked={ queryMode && order === 'ASC' }
 							/>
-							<label htmlFor={`sort-ascending-${clientId}`}>
-								{__('Ascending', 'newspack-listings')}
-							</label>
+							<label htmlFor={ `sort-ascending-${ clientId }` }>{ __( 'Ascending', 'newspack-listings' ) }</label>
 						</div>
 
 						<div>
 							<input
 								disabled
-								id={`sort-descending-${clientId}`}
+								id={ `sort-descending-${ clientId }` }
 								type="radio"
 								name="newspack-listings__sort-order"
 								value="DESC"
-								checked={queryMode && order === 'DESC'}
+								checked={ queryMode && order === 'DESC' }
 							/>
-							<label htmlFor={`sort-descending-${clientId}`}>
-								{__('Descending', 'newspack-listings')}
-							</label>
+							<label htmlFor={ `sort-descending-${ clientId }` }>{ __( 'Descending', 'newspack-listings' ) }</label>
 						</div>
 					</section>
 				</div>
-			)}
+			) }
 			<InnerBlocks
-				allowedBlocks={[
+				allowedBlocks={ [
 					'newspack-listings/event',
 					'newspack-listings/generic',
 					'newspack-listings/marketplace',
 					'newspack-listings/place',
-				]}
-				renderAppender={() =>
-					queryMode ? null : <InnerBlocks.ButtonBlockAppender />
-				}
+				] }
+				renderAppender={ () => ( queryMode ? null : <InnerBlocks.ButtonBlockAppender /> ) }
 			/>
 		</div>
 	);
 };
 
-const mapStateToProps = (select, ownProps) => {
+const mapStateToProps = ( select, ownProps ) => {
 	const { clientId } = ownProps;
-	const { getBlock } = select('core/block-editor');
-	const innerBlocks = getBlock(clientId).innerBlocks || [];
+	const { getBlock } = select( 'core/block-editor' );
+	const innerBlocks = getBlock( clientId ).innerBlocks || [];
 
 	return {
 		innerBlocks,
@@ -128,8 +102,7 @@ const mapStateToProps = (select, ownProps) => {
 };
 
 const mapDispatchToProps = dispatch => {
-	const { insertBlock, removeBlocks, updateBlockAttributes } =
-		dispatch('core/block-editor');
+	const { insertBlock, removeBlocks, updateBlockAttributes } = dispatch( 'core/block-editor' );
 
 	return {
 		insertBlock,
@@ -138,7 +111,4 @@ const mapDispatchToProps = dispatch => {
 	};
 };
 
-export const ListContainerEditor = compose([
-	withSelect(mapStateToProps),
-	withDispatch(mapDispatchToProps),
-])(ListContainerEditorComponent);
+export const ListContainerEditor = compose( [ withSelect( mapStateToProps ), withDispatch( mapDispatchToProps ) ] )( ListContainerEditorComponent );

--- a/src/blocks/list-container/index.js
+++ b/src/blocks/list-container/index.js
@@ -17,6 +17,7 @@ const parentAttributes = parentData.attributes;
 
 export const registerListContainerBlock = () => {
 	registerBlockType( 'newspack-listings/list-container', {
+		apiVersion: 3,
 		title: __( 'Container', 'newspack-listings' ),
 		icon: {
 			src: group,

--- a/src/blocks/list-container/view.php
+++ b/src/blocks/list-container/view.php
@@ -25,6 +25,7 @@ function register_block() {
 	register_block_type(
 		'newspack-listings/list-container',
 		[
+			'api_version'     => 3,
 			'attributes'      => $parent_block_json['attributes'],
 			'render_callback' => __NAMESPACE__ . '\render_block',
 		]

--- a/src/blocks/listing/block.json
+++ b/src/blocks/listing/block.json
@@ -1,18 +1,20 @@
 {
-  "name": "newspack-listings/listing",
-  "category": "newspack",
-  "attributes": {
-    "className": {
-      "type": "string",
-      "default": ""
-    },
-    "listing": {
-      "type": "string",
-      "default": ""
-    },
-    "locations": {
-      "type": "array",
-      "default": []
-    }
-  }
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "newspack-listings/listing",
+	"category": "newspack",
+	"attributes": {
+		"className": {
+			"type": "string",
+			"default": ""
+		},
+		"listing": {
+			"type": "string",
+			"default": ""
+		},
+		"locations": {
+			"type": "array",
+			"default": []
+		}
+	}
 }

--- a/src/blocks/listing/edit.js
+++ b/src/blocks/listing/edit.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
+import { useBlockProps } from '@wordpress/block-editor';
 import { Button, Placeholder, Spinner } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
@@ -16,145 +17,185 @@ import { Listing } from './listing';
 import { AutocompleteWithSuggestions } from 'newspack-components';
 import { capitalize, getIcon } from '../../editor/utils';
 
-const ListingEditorComponent = ( { attributes, clientId, getBlock, getBlockParents, name, setAttributes } ) => {
-	const [ post, setPost ] = useState( null );
-	const [ error, setError ] = useState( null );
-	const [ isEditingPost, setIsEditingPost ] = useState( false );
+const ListingEditorComponent = ({
+	attributes,
+	clientId,
+	getBlock,
+	getBlockParents,
+	name,
+	setAttributes,
+}) => {
+	const blockProps = useBlockProps();
+	const [post, setPost] = useState(null);
+	const [error, setError] = useState(null);
+	const [isEditingPost, setIsEditingPost] = useState(false);
 	const { listing } = attributes;
 
 	// Get the parent List Container block.
-	const parents = getBlockParents( clientId );
-	const parent = parents.reduce( ( acc, outerBlock ) => {
-		const blockInfo = getBlock( outerBlock );
+	const parents = getBlockParents(clientId);
+	const parent = parents.reduce((acc, outerBlock) => {
+		const blockInfo = getBlock(outerBlock);
 
-		if ( 'newspack-listings/list-container' === blockInfo.name ) {
+		if ('newspack-listings/list-container' === blockInfo.name) {
 			acc.listContainer = blockInfo;
 		}
 
 		return acc;
-	}, {} );
+	}, {});
 
 	// Build an array of just the listing post IDs that exist in the parent Curated List block.
-	const listItems = parent.listContainer.innerBlocks.reduce( ( acc, innerBlock ) => {
-		if ( innerBlock.attributes.listing ) {
-			acc.push( innerBlock.attributes.listing );
-		}
+	const listItems = parent.listContainer.innerBlocks.reduce(
+		(acc, innerBlock) => {
+			if (innerBlock.attributes.listing) {
+				acc.push(innerBlock.attributes.listing);
+			}
 
-		return acc;
-	}, [] );
+			return acc;
+		},
+		[]
+	);
 
 	const { post_types } = window.newspack_listings_data;
-	const listingTypeSlug = name.split( '/' ).slice( -1 )[ 0 ];
-	const listingType = post_types[ listingTypeSlug ];
+	const listingTypeSlug = name.split('/').slice(-1)[0];
+	const listingType = post_types[listingTypeSlug];
 
 	// Fetch listing post data if we have a listing post ID.
-	useEffect( () => {
-		if ( ! post && listing ) {
-			fetchPost( listing );
+	useEffect(() => {
+		if (!post && listing) {
+			fetchPost(listing);
 		}
-	}, [ listing ] );
+	}, [listing]);
 
 	// Fetch listing post by listingId.
 	const fetchPost = async listingId => {
 		try {
-			setError( null );
-			const posts = await apiFetch( {
-				path: addQueryArgs( '/newspack-listings/v1/listings', {
+			setError(null);
+			const posts = await apiFetch({
+				path: addQueryArgs('/newspack-listings/v1/listings', {
 					per_page: 100,
 					id: listingId,
-					_fields: 'id,title,author,category,tags,excerpt,media,meta,type,sponsors,classes',
-				} ),
-			} );
+					_fields:
+						'id,title,author,category,tags,excerpt,media,meta,type,sponsors,classes',
+				}),
+			});
 
-			if ( 0 === posts.length ) {
-				throw `No posts found for ID ${ listingId }. Try refreshing or selecting a new post.`;
+			if (0 === posts.length) {
+				throw `No posts found for ID ${listingId}. Try refreshing or selecting a new post.`;
 			}
 
-			const foundPost = posts[ 0 ];
+			const foundPost = posts[0];
 
-			if ( foundPost.meta && foundPost.meta.newspack_listings_locations ) {
-				setAttributes( { locations: foundPost.meta.newspack_listings_locations } );
+			if (foundPost.meta && foundPost.meta.newspack_listings_locations) {
+				setAttributes({
+					locations: foundPost.meta.newspack_listings_locations,
+				});
 			}
 
-			setPost( foundPost );
-		} catch ( e ) {
-			setError( e );
+			setPost(foundPost);
+		} catch (e) {
+			setError(e);
 		}
 	};
 
 	// Renders the autocomplete search field to select listings. Will only show listings of the type that matches the block.
 	const renderSearch = () => {
 		return (
-			<Placeholder className="newspack-listings__listing-search" label={ capitalize( listingTypeSlug ) } icon={ getIcon( listingTypeSlug ) }>
+			<Placeholder
+				className="newspack-listings__listing-search"
+				label={capitalize(listingTypeSlug)}
+				icon={getIcon(listingTypeSlug)}
+			>
 				<AutocompleteWithSuggestions
-					label={ __( 'Search for a', 'newspack-listings' ) + listingTypeSlug + __( 'listing to display.', 'newspack-listings' ) }
-					fetchSavedPosts={ async postIDs => {
-						const posts = await apiFetch( {
-							path: addQueryArgs( 'newspack-listings/v1/listings', {
-								per_page: 100,
-								include: postIDs.join( ',' ),
-								_fields: 'id,title',
-							} ),
-						} );
+					label={
+						__('Search for a', 'newspack-listings') +
+						listingTypeSlug +
+						__('listing to display.', 'newspack-listings')
+					}
+					fetchSavedPosts={async postIDs => {
+						const posts = await apiFetch({
+							path: addQueryArgs(
+								'newspack-listings/v1/listings',
+								{
+									per_page: 100,
+									include: postIDs.join(','),
+									_fields: 'id,title',
+								}
+							),
+						});
 
-						return posts.map( _post => ( {
+						return posts.map(_post => ({
 							value: _post.id,
-							label: decodeEntities( _post.title ) || __( '(no title)', 'newspack-listings' ),
-						} ) );
-					} }
-					fetchSuggestions={ async search => {
-						const posts = await apiFetch( {
-							path: addQueryArgs( '/newspack-listings/v1/listings', {
-								search,
-								per_page: 10,
-								_fields: 'id,title',
-								type: listingType,
-							} ),
-						} );
+							label:
+								decodeEntities(_post.title) ||
+								__('(no title)', 'newspack-listings'),
+						}));
+					}}
+					fetchSuggestions={async search => {
+						const posts = await apiFetch({
+							path: addQueryArgs(
+								'/newspack-listings/v1/listings',
+								{
+									search,
+									per_page: 10,
+									_fields: 'id,title',
+									type: listingType,
+								}
+							),
+						});
 
 						// Only show suggestions if they aren't already in the list.
-						const result = posts.reduce( ( acc, _post ) => {
-							if ( listItems.indexOf( _post.id ) < 0 && listItems.indexOf( _post.id.toString() ) < 0 ) {
-								acc.push( {
+						const result = posts.reduce((acc, _post) => {
+							if (
+								listItems.indexOf(_post.id) < 0 &&
+								listItems.indexOf(_post.id.toString()) < 0
+							) {
+								acc.push({
 									value: _post.id,
-									label: decodeEntities( _post.title ) || __( '(no title)', 'newspack-listings' ),
-								} );
+									label:
+										decodeEntities(_post.title) ||
+										__('(no title)', 'newspack-listings'),
+								});
 							}
 
 							return acc;
-						}, [] );
+						}, []);
 						return result;
-					} }
-					postType={ listingType }
-					postTypeSlug={ listingTypeSlug }
-					maxLength={ 1 }
-					onChange={ _listing => {
-						if ( _listing.length ) {
-							setIsEditingPost( false );
-							setPost( null );
-							setAttributes( { listing: _listing.shift().value.toString() } );
+					}}
+					postType={listingType}
+					postTypeSlug={listingTypeSlug}
+					maxLength={1}
+					onChange={_listing => {
+						if (_listing.length) {
+							setIsEditingPost(false);
+							setPost(null);
+							setAttributes({
+								listing: _listing.shift().value.toString(),
+							});
 						}
-					} }
-					selectedPost={ isEditingPost ? null : listing }
-					listItems={ listItems }
+					}}
+					selectedPost={isEditingPost ? null : listing}
+					listItems={listItems}
 				/>
-				{ listing && (
-					<Button isPrimary onClick={ () => setIsEditingPost( false ) }>
-						{ __( 'Cancel', 'newspack-listings' ) }
+				{listing && (
+					<Button isPrimary onClick={() => setIsEditingPost(false)}>
+						{__('Cancel', 'newspack-listings')}
 					</Button>
-				) }
+				)}
 			</Placeholder>
 		);
 	};
 
 	// Renders selected listing post, or a placeholder if still fetching.
 	const renderPost = () => {
-		if ( ! post && ! error ) {
+		if (!post && !error) {
 			return (
 				<Placeholder
 					className="newspack-listings__listing-search is-loading"
-					label={ listingTypeSlug[ 0 ].toUpperCase() + listingTypeSlug.slice( 1 ) }
-					icon={ getIcon( listingTypeSlug ) }
+					label={
+						listingTypeSlug[0].toUpperCase() +
+						listingTypeSlug.slice(1)
+					}
+					icon={getIcon(listingTypeSlug)}
 				>
 					<Spinner />
 				</Placeholder>
@@ -163,21 +204,29 @@ const ListingEditorComponent = ( { attributes, clientId, getBlock, getBlockParen
 
 		return (
 			<div className="newspack-listings__listing-editor newspack-listings__listing">
-				<Listing attributes={ attributes } error={ error } post={ post } />
-				{ post && (
-					<Button isLink href={ `/wp-admin/post.php?post=${ post.id }&action=edit` } target="_blank">
-						{ __( 'Edit this listing', 'newspack-listings' ) }
+				<Listing attributes={attributes} error={error} post={post} />
+				{post && (
+					<Button
+						isLink
+						href={`/wp-admin/post.php?post=${post.id}&action=edit`}
+						target="_blank"
+					>
+						{__('Edit this listing', 'newspack-listings')}
 					</Button>
-				) }
+				)}
 			</div>
 		);
 	};
 
-	return ! listing || isEditingPost ? renderSearch() : renderPost();
+	return (
+		<div {...blockProps}>
+			{!listing || isEditingPost ? renderSearch() : renderPost()}
+		</div>
+	);
 };
 
 const mapStateToProps = select => {
-	const { getBlock, getBlockParents } = select( 'core/block-editor' );
+	const { getBlock, getBlockParents } = select('core/block-editor');
 
 	return {
 		getBlock,
@@ -185,4 +234,6 @@ const mapStateToProps = select => {
 	};
 };
 
-export const ListingEditor = withSelect( mapStateToProps )( ListingEditorComponent );
+export const ListingEditor = withSelect(mapStateToProps)(
+	ListingEditorComponent
+);

--- a/src/blocks/listing/edit.js
+++ b/src/blocks/listing/edit.js
@@ -17,185 +17,146 @@ import { Listing } from './listing';
 import { AutocompleteWithSuggestions } from 'newspack-components';
 import { capitalize, getIcon } from '../../editor/utils';
 
-const ListingEditorComponent = ({
-	attributes,
-	clientId,
-	getBlock,
-	getBlockParents,
-	name,
-	setAttributes,
-}) => {
+const ListingEditorComponent = ( { attributes, clientId, getBlock, getBlockParents, name, setAttributes } ) => {
+	const [ post, setPost ] = useState( null );
+	const [ error, setError ] = useState( null );
+	const [ isEditingPost, setIsEditingPost ] = useState( false );
 	const blockProps = useBlockProps();
-	const [post, setPost] = useState(null);
-	const [error, setError] = useState(null);
-	const [isEditingPost, setIsEditingPost] = useState(false);
 	const { listing } = attributes;
 
 	// Get the parent List Container block.
-	const parents = getBlockParents(clientId);
-	const parent = parents.reduce((acc, outerBlock) => {
-		const blockInfo = getBlock(outerBlock);
+	const parents = getBlockParents( clientId );
+	const parent = parents.reduce( ( acc, outerBlock ) => {
+		const blockInfo = getBlock( outerBlock );
 
-		if ('newspack-listings/list-container' === blockInfo.name) {
+		if ( 'newspack-listings/list-container' === blockInfo.name ) {
 			acc.listContainer = blockInfo;
 		}
 
 		return acc;
-	}, {});
+	}, {} );
 
 	// Build an array of just the listing post IDs that exist in the parent Curated List block.
-	const listItems = parent.listContainer.innerBlocks.reduce(
-		(acc, innerBlock) => {
-			if (innerBlock.attributes.listing) {
-				acc.push(innerBlock.attributes.listing);
-			}
+	const listItems = parent.listContainer.innerBlocks.reduce( ( acc, innerBlock ) => {
+		if ( innerBlock.attributes.listing ) {
+			acc.push( innerBlock.attributes.listing );
+		}
 
-			return acc;
-		},
-		[]
-	);
+		return acc;
+	}, [] );
 
 	const { post_types } = window.newspack_listings_data;
-	const listingTypeSlug = name.split('/').slice(-1)[0];
-	const listingType = post_types[listingTypeSlug];
+	const listingTypeSlug = name.split( '/' ).slice( -1 )[ 0 ];
+	const listingType = post_types[ listingTypeSlug ];
 
 	// Fetch listing post data if we have a listing post ID.
-	useEffect(() => {
-		if (!post && listing) {
-			fetchPost(listing);
+	useEffect( () => {
+		if ( ! post && listing ) {
+			fetchPost( listing );
 		}
-	}, [listing]);
+	}, [ listing ] );
 
 	// Fetch listing post by listingId.
 	const fetchPost = async listingId => {
 		try {
-			setError(null);
-			const posts = await apiFetch({
-				path: addQueryArgs('/newspack-listings/v1/listings', {
+			setError( null );
+			const posts = await apiFetch( {
+				path: addQueryArgs( '/newspack-listings/v1/listings', {
 					per_page: 100,
 					id: listingId,
-					_fields:
-						'id,title,author,category,tags,excerpt,media,meta,type,sponsors,classes',
-				}),
-			});
+					_fields: 'id,title,author,category,tags,excerpt,media,meta,type,sponsors,classes',
+				} ),
+			} );
 
-			if (0 === posts.length) {
-				throw `No posts found for ID ${listingId}. Try refreshing or selecting a new post.`;
+			if ( 0 === posts.length ) {
+				throw `No posts found for ID ${ listingId }. Try refreshing or selecting a new post.`;
 			}
 
-			const foundPost = posts[0];
+			const foundPost = posts[ 0 ];
 
-			if (foundPost.meta && foundPost.meta.newspack_listings_locations) {
-				setAttributes({
-					locations: foundPost.meta.newspack_listings_locations,
-				});
+			if ( foundPost.meta && foundPost.meta.newspack_listings_locations ) {
+				setAttributes( { locations: foundPost.meta.newspack_listings_locations } );
 			}
 
-			setPost(foundPost);
-		} catch (e) {
-			setError(e);
+			setPost( foundPost );
+		} catch ( e ) {
+			setError( e );
 		}
 	};
 
 	// Renders the autocomplete search field to select listings. Will only show listings of the type that matches the block.
 	const renderSearch = () => {
 		return (
-			<Placeholder
-				className="newspack-listings__listing-search"
-				label={capitalize(listingTypeSlug)}
-				icon={getIcon(listingTypeSlug)}
-			>
+			<Placeholder className="newspack-listings__listing-search" label={ capitalize( listingTypeSlug ) } icon={ getIcon( listingTypeSlug ) }>
 				<AutocompleteWithSuggestions
-					label={
-						__('Search for a', 'newspack-listings') +
-						listingTypeSlug +
-						__('listing to display.', 'newspack-listings')
-					}
-					fetchSavedPosts={async postIDs => {
-						const posts = await apiFetch({
-							path: addQueryArgs(
-								'newspack-listings/v1/listings',
-								{
-									per_page: 100,
-									include: postIDs.join(','),
-									_fields: 'id,title',
-								}
-							),
-						});
+					label={ __( 'Search for a', 'newspack-listings' ) + listingTypeSlug + __( 'listing to display.', 'newspack-listings' ) }
+					fetchSavedPosts={ async postIDs => {
+						const posts = await apiFetch( {
+							path: addQueryArgs( 'newspack-listings/v1/listings', {
+								per_page: 100,
+								include: postIDs.join( ',' ),
+								_fields: 'id,title',
+							} ),
+						} );
 
-						return posts.map(_post => ({
+						return posts.map( _post => ( {
 							value: _post.id,
-							label:
-								decodeEntities(_post.title) ||
-								__('(no title)', 'newspack-listings'),
-						}));
-					}}
-					fetchSuggestions={async search => {
-						const posts = await apiFetch({
-							path: addQueryArgs(
-								'/newspack-listings/v1/listings',
-								{
-									search,
-									per_page: 10,
-									_fields: 'id,title',
-									type: listingType,
-								}
-							),
-						});
+							label: decodeEntities( _post.title ) || __( '(no title)', 'newspack-listings' ),
+						} ) );
+					} }
+					fetchSuggestions={ async search => {
+						const posts = await apiFetch( {
+							path: addQueryArgs( '/newspack-listings/v1/listings', {
+								search,
+								per_page: 10,
+								_fields: 'id,title',
+								type: listingType,
+							} ),
+						} );
 
 						// Only show suggestions if they aren't already in the list.
-						const result = posts.reduce((acc, _post) => {
-							if (
-								listItems.indexOf(_post.id) < 0 &&
-								listItems.indexOf(_post.id.toString()) < 0
-							) {
-								acc.push({
+						const result = posts.reduce( ( acc, _post ) => {
+							if ( listItems.indexOf( _post.id ) < 0 && listItems.indexOf( _post.id.toString() ) < 0 ) {
+								acc.push( {
 									value: _post.id,
-									label:
-										decodeEntities(_post.title) ||
-										__('(no title)', 'newspack-listings'),
-								});
+									label: decodeEntities( _post.title ) || __( '(no title)', 'newspack-listings' ),
+								} );
 							}
 
 							return acc;
-						}, []);
+						}, [] );
 						return result;
-					}}
-					postType={listingType}
-					postTypeSlug={listingTypeSlug}
-					maxLength={1}
-					onChange={_listing => {
-						if (_listing.length) {
-							setIsEditingPost(false);
-							setPost(null);
-							setAttributes({
-								listing: _listing.shift().value.toString(),
-							});
+					} }
+					postType={ listingType }
+					postTypeSlug={ listingTypeSlug }
+					maxLength={ 1 }
+					onChange={ _listing => {
+						if ( _listing.length ) {
+							setIsEditingPost( false );
+							setPost( null );
+							setAttributes( { listing: _listing.shift().value.toString() } );
 						}
-					}}
-					selectedPost={isEditingPost ? null : listing}
-					listItems={listItems}
+					} }
+					selectedPost={ isEditingPost ? null : listing }
+					listItems={ listItems }
 				/>
-				{listing && (
-					<Button isPrimary onClick={() => setIsEditingPost(false)}>
-						{__('Cancel', 'newspack-listings')}
+				{ listing && (
+					<Button isPrimary onClick={ () => setIsEditingPost( false ) }>
+						{ __( 'Cancel', 'newspack-listings' ) }
 					</Button>
-				)}
+				) }
 			</Placeholder>
 		);
 	};
 
 	// Renders selected listing post, or a placeholder if still fetching.
 	const renderPost = () => {
-		if (!post && !error) {
+		if ( ! post && ! error ) {
 			return (
 				<Placeholder
 					className="newspack-listings__listing-search is-loading"
-					label={
-						listingTypeSlug[0].toUpperCase() +
-						listingTypeSlug.slice(1)
-					}
-					icon={getIcon(listingTypeSlug)}
+					label={ listingTypeSlug[ 0 ].toUpperCase() + listingTypeSlug.slice( 1 ) }
+					icon={ getIcon( listingTypeSlug ) }
 				>
 					<Spinner />
 				</Placeholder>
@@ -204,29 +165,25 @@ const ListingEditorComponent = ({
 
 		return (
 			<div className="newspack-listings__listing-editor newspack-listings__listing">
-				<Listing attributes={attributes} error={error} post={post} />
-				{post && (
-					<Button
-						isLink
-						href={`/wp-admin/post.php?post=${post.id}&action=edit`}
-						target="_blank"
-					>
-						{__('Edit this listing', 'newspack-listings')}
+				<Listing attributes={ attributes } error={ error } post={ post } />
+				{ post && (
+					<Button isLink href={ `/wp-admin/post.php?post=${ post.id }&action=edit` } target="_blank">
+						{ __( 'Edit this listing', 'newspack-listings' ) }
 					</Button>
-				)}
+				) }
 			</div>
 		);
 	};
 
 	return (
-		<div {...blockProps}>
-			{!listing || isEditingPost ? renderSearch() : renderPost()}
+		<div { ...blockProps }>
+			{ ! listing || isEditingPost ? renderSearch() : renderPost() }
 		</div>
 	);
 };
 
 const mapStateToProps = select => {
-	const { getBlock, getBlockParents } = select('core/block-editor');
+	const { getBlock, getBlockParents } = select( 'core/block-editor' );
 
 	return {
 		getBlock,
@@ -234,6 +191,4 @@ const mapStateToProps = select => {
 	};
 };
 
-export const ListingEditor = withSelect(mapStateToProps)(
-	ListingEditorComponent
-);
+export const ListingEditor = withSelect( mapStateToProps )( ListingEditorComponent );

--- a/src/blocks/listing/edit.js
+++ b/src/blocks/listing/edit.js
@@ -175,11 +175,7 @@ const ListingEditorComponent = ( { attributes, clientId, getBlock, getBlockParen
 		);
 	};
 
-	return (
-		<div { ...blockProps }>
-			{ ! listing || isEditingPost ? renderSearch() : renderPost() }
-		</div>
-	);
+	return <div { ...blockProps }>{ ! listing || isEditingPost ? renderSearch() : renderPost() }</div>;
 };
 
 const mapStateToProps = select => {

--- a/src/blocks/listing/index.js
+++ b/src/blocks/listing/index.js
@@ -21,6 +21,7 @@ export const registerListingBlock = () => {
 	for ( const listingType in post_types ) {
 		if ( post_types.hasOwnProperty( listingType ) ) {
 			registerBlockType( `newspack-listings/${ listingType }`, {
+				apiVersion: 3,
 				title: listingType.charAt( 0 ).toUpperCase() + listingType.slice( 1 ),
 				icon: {
 					src: getIcon( listingType ),

--- a/src/blocks/listing/view.php
+++ b/src/blocks/listing/view.php
@@ -34,6 +34,7 @@ function register_blocks() {
 		register_block_type(
 			'newspack-listings/' . $label,
 			[
+				'api_version'     => $block_json['apiVersion'],
 				'attributes'      => $attributes,
 				'render_callback' => __NAMESPACE__ . '\render_block',
 			]

--- a/src/blocks/price/block.json
+++ b/src/blocks/price/block.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "newspack-listings/price",
 	"category": "newspack",
 	"attributes": {

--- a/src/blocks/price/edit.js
+++ b/src/blocks/price/edit.js
@@ -2,92 +2,117 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, PanelRow, Placeholder, SelectControl, TextControl, ToggleControl } from '@wordpress/components';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	PanelRow,
+	Placeholder,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { currencyDollar } from '@wordpress/icons';
 
-export const PriceEditor = ( { attributes, isSelected, setAttributes } ) => {
-	const { currencies = {}, currency: defaultCurrency = 'USD' } = window.newspack_listings_data;
+export const PriceEditor = ({ attributes, isSelected, setAttributes }) => {
+	const blockProps = useBlockProps();
+	const { currencies = {}, currency: defaultCurrency = 'USD' } =
+		window.newspack_listings_data;
 	const locale = window.navigator?.language || 'en-US';
 	const { currency, formattedPrice, price, showDecimals } = attributes;
 
-	useEffect( () => {
+	useEffect(() => {
 		// Guard against setting invalid price attribute.
-		if ( isNaN( price ) || '' === price || 0 > price ) {
-			setAttributes( { price: 0 } );
+		if (isNaN(price) || '' === price || 0 > price) {
+			setAttributes({ price: 0 });
 		}
-	}, [ isSelected ] );
+	}, [isSelected]);
 
-	useEffect( () => {
+	useEffect(() => {
 		// Guard against rendering invalid price attribute.
-		const priceToFormat = isNaN( price ) || '' === price || 0 > price ? 0 : price;
+		const priceToFormat =
+			isNaN(price) || '' === price || 0 > price ? 0 : price;
 
 		// Format price according to editor's locale.
-		setAttributes( {
-			formattedPrice: new Intl.NumberFormat( locale, {
+		setAttributes({
+			formattedPrice: new Intl.NumberFormat(locale, {
 				style: 'currency',
 				currency: currency || defaultCurrency,
 				minimumFractionDigits: showDecimals ? 2 : 0,
 				maximumFractionDigits: showDecimals ? 2 : 0,
-			} ).format( priceToFormat ),
-		} );
-	}, [ currency, showDecimals, price ] );
+			}).format(priceToFormat),
+		});
+	}, [currency, showDecimals, price]);
 
 	return (
-		<>
+		<div {...blockProps}>
 			<InspectorControls>
-				<PanelBody title={ __( 'Price Settings' ) }>
-					{ 0 < Object.keys( currencies ).length && (
+				<PanelBody title={__('Price Settings')}>
+					{0 < Object.keys(currencies).length && (
 						<SelectControl
-							label={ __( 'Select currency', 'newspack-listings' ) }
-							value={ currency || defaultCurrency }
-							onChange={ value => setAttributes( { currency: value } ) }
-							options={ Object.keys( currencies )
-								.map( _currency => {
+							label={__('Select currency', 'newspack-listings')}
+							value={currency || defaultCurrency}
+							onChange={value =>
+								setAttributes({ currency: value })
+							}
+							options={Object.keys(currencies)
+								.map(_currency => {
 									return {
 										value: _currency,
-										label: `${ decodeEntities( currencies[ _currency ] ) } (${ _currency })`,
+										label: `${decodeEntities(currencies[_currency])} (${_currency})`,
 									};
-								} )
-								.sort( ( a, b ) => a.label.toUpperCase().localeCompare( b.label.toUpperCase() ) ) }
+								})
+								.sort((a, b) =>
+									a.label
+										.toUpperCase()
+										.localeCompare(b.label.toUpperCase())
+								)}
 						/>
-					) }
+					)}
 					<PanelRow>
 						<ToggleControl
 							className="newspack-listings__decimals-toggle"
-							label={ __( 'Show decimals', 'newspack-listings' ) }
-							help={ __( 'If disabled, the price shown will be rounded to the nearest integer.', 'newspack-listings' ) }
-							checked={ showDecimals }
-							onChange={ value => setAttributes( { showDecimals: value } ) }
+							label={__('Show decimals', 'newspack-listings')}
+							help={__(
+								'If disabled, the price shown will be rounded to the nearest integer.',
+								'newspack-listings'
+							)}
+							checked={showDecimals}
+							onChange={value =>
+								setAttributes({ showDecimals: value })
+							}
 						/>
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
 
-			{ isSelected ? (
-				<Placeholder icon={ currencyDollar } label={ __( 'Price', 'newspack-listings' ) } isColumnLayout>
+			{isSelected ? (
+				<Placeholder
+					icon={currencyDollar}
+					label={__('Price', 'newspack-listings')}
+					isColumnLayout
+				>
 					<TextControl
-						label={ sprintf(
+						label={sprintf(
 							// translators: %s: currency.
-							__( 'Price in %s', 'newspack-listings' ),
+							__('Price in %s', 'newspack-listings'),
 							currency || defaultCurrency
-						) }
+						)}
 						type="number"
-						value={ price }
-						onChange={ value => {
-							setAttributes( {
-								price: parseFloat( value < 0 ? 0 : value ),
-							} );
-						} }
+						value={price}
+						onChange={value => {
+							setAttributes({
+								price: parseFloat(value < 0 ? 0 : value),
+							});
+						}}
 					/>
 				</Placeholder>
 			) : (
 				<p className="newspack-listings__price has-large-font-size">
-					<strong>{ formattedPrice }</strong>
+					<strong>{formattedPrice}</strong>
 				</p>
-			) }
-		</>
+			)}
+		</div>
 	);
 };

--- a/src/blocks/price/edit.js
+++ b/src/blocks/price/edit.js
@@ -68,26 +68,26 @@ export const PriceEditor = ( { attributes, isSelected, setAttributes } ) => {
 			</InspectorControls>
 			<div { ...blockProps }>
 				{ isSelected ? (
-				<Placeholder icon={ currencyDollar } label={ __( 'Price', 'newspack-listings' ) } isColumnLayout>
-					<TextControl
-						label={ sprintf(
-							// translators: %s: currency.
-							__( 'Price in %s', 'newspack-listings' ),
-							currency || defaultCurrency
-						) }
-						type="number"
-						value={ price }
-						onChange={ value => {
-							setAttributes( {
-								price: parseFloat( value < 0 ? 0 : value ),
-							} );
-						} }
-					/>
-				</Placeholder>
-			) : (
-				<p className="newspack-listings__price has-large-font-size">
-					<strong>{ formattedPrice }</strong>
-				</p>
+					<Placeholder icon={ currencyDollar } label={ __( 'Price', 'newspack-listings' ) } isColumnLayout>
+						<TextControl
+							label={ sprintf(
+								// translators: %s: currency.
+								__( 'Price in %s', 'newspack-listings' ),
+								currency || defaultCurrency
+							) }
+							type="number"
+							value={ price }
+							onChange={ value => {
+								setAttributes( {
+									price: parseFloat( value < 0 ? 0 : value ),
+								} );
+							} }
+						/>
+					</Placeholder>
+				) : (
+					<p className="newspack-listings__price has-large-font-size">
+						<strong>{ formattedPrice }</strong>
+					</p>
 				) }
 			</div>
 		</>

--- a/src/blocks/price/edit.js
+++ b/src/blocks/price/edit.js
@@ -37,7 +37,7 @@ export const PriceEditor = ( { attributes, isSelected, setAttributes } ) => {
 	}, [ currency, showDecimals, price ] );
 
 	return (
-		<div { ...blockProps }>
+		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Price Settings' ) }>
 					{ 0 < Object.keys( currencies ).length && (
@@ -66,8 +66,8 @@ export const PriceEditor = ( { attributes, isSelected, setAttributes } ) => {
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
-
-			{ isSelected ? (
+			<div { ...blockProps }>
+				{ isSelected ? (
 				<Placeholder icon={ currencyDollar } label={ __( 'Price', 'newspack-listings' ) } isColumnLayout>
 					<TextControl
 						label={ sprintf(
@@ -88,7 +88,8 @@ export const PriceEditor = ( { attributes, isSelected, setAttributes } ) => {
 				<p className="newspack-listings__price has-large-font-size">
 					<strong>{ formattedPrice }</strong>
 				</p>
-			) }
-		</div>
+				) }
+			</div>
+		</>
 	);
 };

--- a/src/blocks/price/edit.js
+++ b/src/blocks/price/edit.js
@@ -3,116 +3,92 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import {
-	PanelBody,
-	PanelRow,
-	Placeholder,
-	SelectControl,
-	TextControl,
-	ToggleControl,
-} from '@wordpress/components';
+import { PanelBody, PanelRow, Placeholder, SelectControl, TextControl, ToggleControl } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { currencyDollar } from '@wordpress/icons';
 
-export const PriceEditor = ({ attributes, isSelected, setAttributes }) => {
-	const blockProps = useBlockProps();
-	const { currencies = {}, currency: defaultCurrency = 'USD' } =
-		window.newspack_listings_data;
+export const PriceEditor = ( { attributes, isSelected, setAttributes } ) => {
+	const { currencies = {}, currency: defaultCurrency = 'USD' } = window.newspack_listings_data;
 	const locale = window.navigator?.language || 'en-US';
 	const { currency, formattedPrice, price, showDecimals } = attributes;
+	const blockProps = useBlockProps();
 
-	useEffect(() => {
+	useEffect( () => {
 		// Guard against setting invalid price attribute.
-		if (isNaN(price) || '' === price || 0 > price) {
-			setAttributes({ price: 0 });
+		if ( isNaN( price ) || '' === price || 0 > price ) {
+			setAttributes( { price: 0 } );
 		}
-	}, [isSelected]);
+	}, [ isSelected ] );
 
-	useEffect(() => {
+	useEffect( () => {
 		// Guard against rendering invalid price attribute.
-		const priceToFormat =
-			isNaN(price) || '' === price || 0 > price ? 0 : price;
+		const priceToFormat = isNaN( price ) || '' === price || 0 > price ? 0 : price;
 
 		// Format price according to editor's locale.
-		setAttributes({
-			formattedPrice: new Intl.NumberFormat(locale, {
+		setAttributes( {
+			formattedPrice: new Intl.NumberFormat( locale, {
 				style: 'currency',
 				currency: currency || defaultCurrency,
 				minimumFractionDigits: showDecimals ? 2 : 0,
 				maximumFractionDigits: showDecimals ? 2 : 0,
-			}).format(priceToFormat),
-		});
-	}, [currency, showDecimals, price]);
+			} ).format( priceToFormat ),
+		} );
+	}, [ currency, showDecimals, price ] );
 
 	return (
-		<div {...blockProps}>
+		<div { ...blockProps }>
 			<InspectorControls>
-				<PanelBody title={__('Price Settings')}>
-					{0 < Object.keys(currencies).length && (
+				<PanelBody title={ __( 'Price Settings' ) }>
+					{ 0 < Object.keys( currencies ).length && (
 						<SelectControl
-							label={__('Select currency', 'newspack-listings')}
-							value={currency || defaultCurrency}
-							onChange={value =>
-								setAttributes({ currency: value })
-							}
-							options={Object.keys(currencies)
-								.map(_currency => {
+							label={ __( 'Select currency', 'newspack-listings' ) }
+							value={ currency || defaultCurrency }
+							onChange={ value => setAttributes( { currency: value } ) }
+							options={ Object.keys( currencies )
+								.map( _currency => {
 									return {
 										value: _currency,
-										label: `${decodeEntities(currencies[_currency])} (${_currency})`,
+										label: `${ decodeEntities( currencies[ _currency ] ) } (${ _currency })`,
 									};
-								})
-								.sort((a, b) =>
-									a.label
-										.toUpperCase()
-										.localeCompare(b.label.toUpperCase())
-								)}
+								} )
+								.sort( ( a, b ) => a.label.toUpperCase().localeCompare( b.label.toUpperCase() ) ) }
 						/>
-					)}
+					) }
 					<PanelRow>
 						<ToggleControl
 							className="newspack-listings__decimals-toggle"
-							label={__('Show decimals', 'newspack-listings')}
-							help={__(
-								'If disabled, the price shown will be rounded to the nearest integer.',
-								'newspack-listings'
-							)}
-							checked={showDecimals}
-							onChange={value =>
-								setAttributes({ showDecimals: value })
-							}
+							label={ __( 'Show decimals', 'newspack-listings' ) }
+							help={ __( 'If disabled, the price shown will be rounded to the nearest integer.', 'newspack-listings' ) }
+							checked={ showDecimals }
+							onChange={ value => setAttributes( { showDecimals: value } ) }
 						/>
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
 
-			{isSelected ? (
-				<Placeholder
-					icon={currencyDollar}
-					label={__('Price', 'newspack-listings')}
-					isColumnLayout
-				>
+			{ isSelected ? (
+				<Placeholder icon={ currencyDollar } label={ __( 'Price', 'newspack-listings' ) } isColumnLayout>
 					<TextControl
-						label={sprintf(
+						label={ sprintf(
 							// translators: %s: currency.
-							__('Price in %s', 'newspack-listings'),
+							__( 'Price in %s', 'newspack-listings' ),
 							currency || defaultCurrency
-						)}
+						) }
 						type="number"
-						value={price}
-						onChange={value => {
-							setAttributes({
-								price: parseFloat(value < 0 ? 0 : value),
-							});
-						}}
+						value={ price }
+						onChange={ value => {
+							setAttributes( {
+								price: parseFloat( value < 0 ? 0 : value ),
+							} );
+						} }
 					/>
 				</Placeholder>
 			) : (
 				<p className="newspack-listings__price has-large-font-size">
-					<strong>{formattedPrice}</strong>
+					<strong>{ formattedPrice }</strong>
 				</p>
-			)}
+			) }
 		</div>
 	);
 };

--- a/src/blocks/price/index.js
+++ b/src/blocks/price/index.js
@@ -14,6 +14,7 @@ const { attributes, category, name } = metadata;
 
 export const registerPriceBlock = () => {
 	registerBlockType( name, {
+		apiVersion: 3,
 		title: __( 'Price', 'newspack-listings' ),
 		icon: {
 			src: currencyDollar,

--- a/src/blocks/price/view.php
+++ b/src/blocks/price/view.php
@@ -14,17 +14,10 @@ use Newspack_Listings\Utils;
  * Dynamic block registration.
  */
 function register_block() {
-	// Block attributes.
-	$block_json = json_decode(
-		file_get_contents( __DIR__ . '/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		true
-	);
-
 	// Register Price block.
 	register_block_type(
-		$block_json['name'],
+		__DIR__,
 		[
-			'attributes'      => $block_json['attributes'],
 			'render_callback' => __NAMESPACE__ . '\render_block',
 		]
 	);

--- a/src/blocks/self-serve-listings/block.json
+++ b/src/blocks/self-serve-listings/block.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "newspack-listings/self-serve-listings",
 	"category": "newspack",
 	"attributes": {

--- a/src/blocks/self-serve-listings/edit.js
+++ b/src/blocks/self-serve-listings/edit.js
@@ -171,7 +171,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 							/>
 							<label
 								className="freq-label listing-single"
-								htmlFor="listing-single"
+								htmlFor="listing-single-${ clientId }"
 								onClick={ () => setSelectedType( 'single' ) }
 							>
 								{ __( 'Single Listing' ) }
@@ -212,7 +212,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 								<label htmlFor={ `listing-type-${ clientId }` }>
 									{ __( 'Listing Type', 'newspack-listings' ) }
 								</label>
-								<select id={ `${ clientId }` } name="listing-single-type">
+								<select id={ `listing-type-${ clientId }` } name="listing-single-type">
 									{ allowedSingleListingTypes.map( listingType => (
 										<option key={ listingType.slug } value={ `listing-type-${ listingType.slug }` }>
 											{ listingType.name }
@@ -249,7 +249,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 							/>
 							<label
 								className="freq-label listing-subscription"
-								htmlFor="listing-subscription"
+								htmlFor="listing-subscription-${ clientId }"
 								onClick={ () => setSelectedType( 'subscription' ) }
 							>
 								{ __( 'Listing Subscription' ) }

--- a/src/blocks/self-serve-listings/edit.js
+++ b/src/blocks/self-serve-listings/edit.js
@@ -227,7 +227,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 								<label htmlFor={ `listing-single-upgrade-${ clientId }` }>
 									{ __( 'Upgrade to a featured listing', 'newspack-listings' ) }
 								</label>
-								<p class="newspack-listings__help">
+								<p className="newspack-listings__help">
 									{ __(
 										'Featured listings appear first in lists, directory pages and search results.',
 										'newspack-listings'
@@ -290,7 +290,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 								<label htmlFor={ `listing-subscription-upgrade-${ clientId }` }>
 									{ __( 'Upgrade to a premium subscription', 'newspack-listings' ) }
 								</label>
-								<p class="newspack-listings__help">
+								<p className="newspack-listings__help">
 									{ __(
 										'A premium subscription upgrades your listing to "featured" status and lets you create up to 10 additional Marketplace or Event listings.',
 										'newspack-listings'

--- a/src/blocks/self-serve-listings/edit.js
+++ b/src/blocks/self-serve-listings/edit.js
@@ -170,7 +170,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 							/>
 							<label
 								className="freq-label listing-single"
-								htmlFor="listing-single"
+								htmlFor={ `listing-single-${ clientId }` }
 								onClick={ () => setSelectedType( 'single' ) }
 							>
 								{ __( 'Single Listing' ) }
@@ -248,7 +248,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 							/>
 							<label
 								className="freq-label listing-subscription"
-								htmlFor="listing-subscription"
+								htmlFor={ `listing-subscription-${ clientId }` }
 								onClick={ () => setSelectedType( 'subscription' ) }
 							>
 								{ __( 'Listing Subscription' ) }

--- a/src/blocks/self-serve-listings/edit.js
+++ b/src/blocks/self-serve-listings/edit.js
@@ -62,7 +62,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 	}
 
 	return (
-		<div { ...blockProps }>
+		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Self-Serve Listing Settings' ) }>
 					<PanelRow>
@@ -154,7 +154,8 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 					) }
 				</PanelBody>
 			</InspectorControls>
-			<div className={ classNames.join( ' ' ) }>
+			<div { ...blockProps }>
+				<div className={ classNames.join( ' ' ) }>
 				<form>
 				<div className="frequencies">
 					{ ( 'subscription-only' !== allowedPurchases || false === allowSubscription ) && (
@@ -308,7 +309,8 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 					/>
 				</button>
 				</form>
+				</div>
 			</div>
-		</div>
+		</>
 	);
 };

--- a/src/blocks/self-serve-listings/edit.js
+++ b/src/blocks/self-serve-listings/edit.js
@@ -48,9 +48,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 	}, [ allowSubscription ] );
 
 	const classNames = [ 'newspack-listings__self-serve-form', 'wpbnbd', allowedPurchases ];
-	const blockProps = useBlockProps( {
-		className: classNames.join( ' ' ),
-	} );
+	const blockProps = useBlockProps();
 
 	const getPurchaseTypeLabel = () => {
 		switch (allowedPurchases) {
@@ -156,7 +154,8 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 					) }
 				</PanelBody>
 			</InspectorControls>
-			<form>
+			<div className={ classNames.join( ' ' ) }>
+				<form>
 				<div className="frequencies">
 					{ ( 'subscription-only' !== allowedPurchases || false === allowSubscription ) && (
 						<div className="newspack-listings__form-tabs frequency">
@@ -171,7 +170,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 							/>
 							<label
 								className="freq-label listing-single"
-								htmlFor="listing-single-${ clientId }"
+								htmlFor="listing-single"
 								onClick={ () => setSelectedType( 'single' ) }
 							>
 								{ __( 'Single Listing' ) }
@@ -212,7 +211,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 								<label htmlFor={ `listing-type-${ clientId }` }>
 									{ __( 'Listing Type', 'newspack-listings' ) }
 								</label>
-								<select id={ `listing-type-${ clientId }` } name="listing-single-type">
+								<select id={ `${ clientId }` } name="listing-single-type">
 									{ allowedSingleListingTypes.map( listingType => (
 										<option key={ listingType.slug } value={ `listing-type-${ listingType.slug }` }>
 											{ listingType.name }
@@ -249,7 +248,7 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 							/>
 							<label
 								className="freq-label listing-subscription"
-								htmlFor="listing-subscription-${ clientId }"
+								htmlFor="listing-subscription"
 								onClick={ () => setSelectedType( 'subscription' ) }
 							>
 								{ __( 'Listing Subscription' ) }
@@ -308,7 +307,8 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 						tagName="span"
 					/>
 				</button>
-			</form>
+				</form>
+			</div>
 		</div>
 	);
 };

--- a/src/blocks/self-serve-listings/edit.js
+++ b/src/blocks/self-serve-listings/edit.js
@@ -4,7 +4,11 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { InspectorControls, RichText } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import {
 	BaseControl,
 	CheckboxControl,
@@ -25,9 +29,13 @@ const {
 	self_serve_listing_expiration: singleExpirationPeriod = 30,
 } = window.newspack_listings_data || {};
 
-export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes } ) => {
-	const [ selectedType, setSelectedType ] = useState( 'single' );
-	const [ error, setError ] = useState( null );
+export const SelfServeListingsEditor = ({
+	attributes,
+	clientId,
+	setAttributes,
+}) => {
+	const [selectedType, setSelectedType] = useState('single');
+	const [error, setError] = useState(null);
 	const {
 		allowedSingleListingTypes,
 		allowSubscription, // Legacy attribute superseded by allowedPurchases.
@@ -37,96 +45,152 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 		subscriptionDescription,
 	} = attributes;
 
-	useEffect( () => {
-		setAttributes( { clientId } );
-	}, [ clientId ] );
+	useEffect(() => {
+		setAttributes({ clientId });
+	}, [clientId]);
 
-	useEffect( () => {
-		if ( false === allowSubscription ) {
-			setAttributes( { allowedPurchases: 'single-only' } );
+	useEffect(() => {
+		if (false === allowSubscription) {
+			setAttributes({ allowedPurchases: 'single-only' });
 		}
-	}, [ allowSubscription ] );
+	}, [allowSubscription]);
 
-	const classNames = [ 'newspack-listings__self-serve-form', 'wpbnbd', allowedPurchases ];
+	const classNames = [
+		'newspack-listings__self-serve-form',
+		'wpbnbd',
+		allowedPurchases,
+	];
+	const blockProps = useBlockProps({
+		className: classNames.join(' '),
+	});
 
 	const getPurchaseTypeLabel = () => {
 		switch (allowedPurchases) {
 			case 'both':
-				return __( 'both single listings and subscriptions', 'newspack-listings' );
+				return __(
+					'both single listings and subscriptions',
+					'newspack-listings'
+				);
 			case 'single-only':
-				return __( 'single listings only', 'newspack-listings' );
+				return __('single listings only', 'newspack-listings');
 			case 'subscription-only':
-				return __( 'subscription listings only', 'newspack-listings' );
+				return __('subscription listings only', 'newspack-listings');
 		}
-	}
+	};
 
 	return (
-		<>
+		<div {...blockProps}>
 			<InspectorControls>
-				<PanelBody title={ __( 'Self-Serve Listing Settings' ) }>
+				<PanelBody title={__('Self-Serve Listing Settings')}>
 					<PanelRow>
 						<SelectControl
-							label={ __( 'Purchase Types Allowed', 'newspack-listings' ) }
-							help={ sprintf(
-								__( 'Allow readers to purchase %s.', 'newspack-listings' ),
+							label={__(
+								'Purchase Types Allowed',
+								'newspack-listings'
+							)}
+							help={sprintf(
+								__(
+									'Allow readers to purchase %s.',
+									'newspack-listings'
+								),
 								getPurchaseTypeLabel()
-							) }
-							onChange={ value => setAttributes( { allowedPurchases: value, allowSubscription: true } ) }
-							value={ false === allowSubscription ? 'single-only' : allowedPurchases }
-							options={ [
+							)}
+							onChange={value =>
+								setAttributes({
+									allowedPurchases: value,
+									allowSubscription: true,
+								})
+							}
+							value={
+								false === allowSubscription
+									? 'single-only'
+									: allowedPurchases
+							}
+							options={[
 								{
-									label: __( 'Single listings and subscriptions', 'newspack-listings' ),
-									value: 'both'
+									label: __(
+										'Single listings and subscriptions',
+										'newspack-listings'
+									),
+									value: 'both',
 								},
 								{
-									label: __( 'Single listings only', 'newspack-listings' ),
-									value: 'single-only'
+									label: __(
+										'Single listings only',
+										'newspack-listings'
+									),
+									value: 'single-only',
 								},
 								{
-									label: __( 'Subscriptions only', 'newspack-listings' ),
-									value: 'subscription-only'
+									label: __(
+										'Subscriptions only',
+										'newspack-listings'
+									),
+									value: 'subscription-only',
 								},
-							] }
+							]}
 						/>
 					</PanelRow>
-					{ 'subscription-only' !== allowedPurchases && (
+					{'subscription-only' !== allowedPurchases && (
 						<BaseControl
 							id="newspack-listings-allowed-single-listing-types"
-							help={ __(
+							help={__(
 								'Choose which listing types users are allowed to purchase.',
 								'newspack-listings'
-							) }
-							label={ __( 'Allowed Single Listing Types', 'newspack-listings' ) }
+							)}
+							label={__(
+								'Allowed Single Listing Types',
+								'newspack-listings'
+							)}
 						>
-							{ singleListingTypes.map( listingType => {
-								const isAllowed = allowedSingleListingTypes.reduce( ( acc, type ) => {
-									if ( type.slug === listingType.slug ) {
-										return true;
-									}
-									return acc;
-								}, false );
+							{singleListingTypes.map(listingType => {
+								const isAllowed =
+									allowedSingleListingTypes.reduce(
+										(acc, type) => {
+											if (
+												type.slug === listingType.slug
+											) {
+												return true;
+											}
+											return acc;
+										},
+										false
+									);
 								return (
-									<PanelRow key={ listingType.slug }>
+									<PanelRow key={listingType.slug}>
 										<CheckboxControl
-											label={ listingType.name }
-											checked={ isAllowed }
-											onChange={ value => {
-												setError( null );
-												if ( ( value && isAllowed ) || ( ! value && ! isAllowed ) ) {
+											label={listingType.name}
+											checked={isAllowed}
+											onChange={value => {
+												setError(null);
+												if (
+													(value && isAllowed) ||
+													(!value && !isAllowed)
+												) {
 													return false;
 												}
 
-												let newAllowedListingTypes = [ ...allowedSingleListingTypes ];
+												let newAllowedListingTypes = [
+													...allowedSingleListingTypes,
+												];
 
-												if ( value ) {
-													newAllowedListingTypes.push( listingType );
-												} else {
-													newAllowedListingTypes = allowedSingleListingTypes.filter(
-														type => type.slug !== listingType.slug
+												if (value) {
+													newAllowedListingTypes.push(
+														listingType
 													);
+												} else {
+													newAllowedListingTypes =
+														allowedSingleListingTypes.filter(
+															type =>
+																type.slug !==
+																listingType.slug
+														);
 												}
 
-												if ( 0 === newAllowedListingTypes.length ) {
+												if (
+													0 ===
+													newAllowedListingTypes.length
+												) {
 													setError(
 														__(
 															'You must allow at least one listing type for purchase.',
@@ -136,178 +200,234 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 													return false;
 												}
 
-												setAttributes( {
-													allowedSingleListingTypes: newAllowedListingTypes,
-												} );
-											} }
+												setAttributes({
+													allowedSingleListingTypes:
+														newAllowedListingTypes,
+												});
+											}}
 										/>
 									</PanelRow>
 								);
-							} ) }
+							})}
 						</BaseControl>
-					) }
-					{ error && (
-						<Notice className="newspack-listings__error" status="error" isDismissible={ false }>
-							{ error }
+					)}
+					{error && (
+						<Notice
+							className="newspack-listings__error"
+							status="error"
+							isDismissible={false}
+						>
+							{error}
 						</Notice>
-					) }
+					)}
 				</PanelBody>
 			</InspectorControls>
-			<div className={ classNames.join( ' ' ) }>
-				<form>
-					<div className="frequencies">
-						{ ( 'subscription-only' !== allowedPurchases || false === allowSubscription ) && (
-							<div className="newspack-listings__form-tabs frequency">
+			<form>
+				<div className="frequencies">
+					{('subscription-only' !== allowedPurchases ||
+						false === allowSubscription) && (
+						<div className="newspack-listings__form-tabs frequency">
+							<input
+								name="listing-purchase-type"
+								className="newspack-listings__tab-input"
+								id={`listing-single-${clientId}`}
+								type="radio"
+								value="listing-single"
+								checked={
+									'single' === selectedType ||
+									'single-only' === allowedPurchases ||
+									false === allowSubscription
+								}
+								onClick={() => setSelectedType('single')}
+							/>
+							<label
+								className="freq-label listing-single"
+								htmlFor="listing-single"
+								onClick={() => setSelectedType('single')}
+							>
+								{__('Single Listing')}
+							</label>
+							<div className="input-container listing-details">
+								<RichText
+									onChange={value =>
+										setAttributes({
+											singleDescription: value,
+										})
+									}
+									placeholder={__(
+										'Description text for your single listing product…',
+										'newspack-listings'
+									)}
+									value={singleDescription}
+									tagName="p"
+								/>
+								{singleExpirationPeriod && (
+									<p className="newspack-listings__help">
+										{sprintf(
+											__(
+												'Single-purchase listings expire %d days after the date of publication.',
+												'newspack-listings'
+											),
+											singleExpirationPeriod
+										)}
+									</p>
+								)}
+								<hr />
+								<h3>
+									{__('Listing Details', 'newspack-listings')}
+								</h3>
+								<label
+									htmlFor={`listing-title-single-${clientId}`}
+								>
+									{__('Listing Title', 'newspack-listings')}
+								</label>
 								<input
-									name="listing-purchase-type"
-									className="newspack-listings__tab-input"
-									id={ `listing-single-${ clientId }` }
-									type="radio"
-									value="listing-single"
-									checked={ 'single' === selectedType || 'single-only' === allowedPurchases || false === allowSubscription }
-									onClick={ () => setSelectedType( 'single' ) }
+									type="text"
+									id={`listing-title-single-${clientId}`}
+									name="listing-title-single"
+									value=""
+									placeholder={__('My Listing Title')}
+								/>
+								<label htmlFor={`listing-type-${clientId}`}>
+									{__('Listing Type', 'newspack-listings')}
+								</label>
+								<select
+									id={`${clientId}`}
+									name="listing-single-type"
+								>
+									{allowedSingleListingTypes.map(
+										listingType => (
+											<option
+												key={listingType.slug}
+												value={`listing-type-${listingType.slug}`}
+											>
+												{listingType.name}
+											</option>
+										)
+									)}
+								</select>
+								<input
+									type="checkbox"
+									id={`listing-single-upgrade-${clientId}`}
+									name="listing-featured-upgrade"
 								/>
 								<label
-									className="freq-label listing-single"
-									htmlFor="listing-single"
-									onClick={ () => setSelectedType( 'single' ) }
+									htmlFor={`listing-single-upgrade-${clientId}`}
 								>
-									{ __( 'Single Listing' ) }
+									{__(
+										'Upgrade to a featured listing',
+										'newspack-listings'
+									)}
 								</label>
-								<div className="input-container listing-details">
-									<RichText
-										onChange={ value => setAttributes( { singleDescription: value } ) }
-										placeholder={ __(
-											'Description text for your single listing product…',
-											'newspack-listings'
-										) }
-										value={ singleDescription }
-										tagName="p"
-									/>
-									{ singleExpirationPeriod && (
-										<p className="newspack-listings__help">
-											{ sprintf(
-												__(
-													'Single-purchase listings expire %d days after the date of publication.',
-													'newspack-listings'
-												),
-												singleExpirationPeriod
-											) }
-										</p>
-									) }
-									<hr />
-									<h3>{ __( 'Listing Details', 'newspack-listings' ) }</h3>
-									<label htmlFor={ `listing-title-single-${ clientId }` }>
-										{ __( 'Listing Title', 'newspack-listings' ) }
-									</label>
-									<input
-										type="text"
-										id={ `listing-title-single-${ clientId }` }
-										name="listing-title-single"
-										value=""
-										placeholder={ __( 'My Listing Title' ) }
-									/>
-									<label htmlFor={ `listing-type-${ clientId }` }>
-										{ __( 'Listing Type', 'newspack-listings' ) }
-									</label>
-									<select id={ `${ clientId }` } name="listing-single-type">
-										{ allowedSingleListingTypes.map( listingType => (
-											<option key={ listingType.slug } value={ `listing-type-${ listingType.slug }` }>
-												{ listingType.name }
-											</option>
-										) ) }
-									</select>
-									<input
-										type="checkbox"
-										id={ `listing-single-upgrade-${ clientId }` }
-										name="listing-featured-upgrade"
-									/>
-									<label htmlFor={ `listing-single-upgrade-${ clientId }` }>
-										{ __( 'Upgrade to a featured listing', 'newspack-listings' ) }
-									</label>
-									<p class="newspack-listings__help">
-										{ __(
-											'Featured listings appear first in lists, directory pages and search results.',
-											'newspack-listings'
-										) }
-									</p>
-								</div>
+								<p class="newspack-listings__help">
+									{__(
+										'Featured listings appear first in lists, directory pages and search results.',
+										'newspack-listings'
+									)}
+								</p>
 							</div>
-						) }
-						{ ( 'single-only' !== allowedPurchases && false !== allowSubscription ) && (
+						</div>
+					)}
+					{'single-only' !== allowedPurchases &&
+						false !== allowSubscription && (
 							<div className="newspack-listings__form-tabs frequency">
 								<input
 									name="listing-purchase-type"
 									className="newspack-listings__tab-input"
-									id={ `listing-subscription-${ clientId }` }
+									id={`listing-subscription-${clientId}`}
 									type="radio"
 									value="listing-subscription"
-									checked={ 'subscription' === selectedType || 'subscription-only' === allowedPurchases }
-									onClick={ () => setSelectedType( 'subscription' ) }
+									checked={
+										'subscription' === selectedType ||
+										'subscription-only' === allowedPurchases
+									}
+									onClick={() =>
+										setSelectedType('subscription')
+									}
 								/>
 								<label
 									className="freq-label listing-subscription"
 									htmlFor="listing-subscription"
-									onClick={ () => setSelectedType( 'subscription' ) }
+									onClick={() =>
+										setSelectedType('subscription')
+									}
 								>
-									{ __( 'Listing Subscription' ) }
+									{__('Listing Subscription')}
 								</label>
 								<div className="input-container listing-details">
 									<RichText
-										onChange={ value => setAttributes( { subscriptionDescription: value } ) }
-										placeholder={ __(
+										onChange={value =>
+											setAttributes({
+												subscriptionDescription: value,
+											})
+										}
+										placeholder={__(
 											'Description text for your subscription product…',
 											'newspack-listings'
-										) }
-										value={ subscriptionDescription }
+										)}
+										value={subscriptionDescription}
 										tagName="p"
 									/>
 									<p className="newspack-listings__help">
-										{ __(
+										{__(
 											'Subscription listings remain live as long as the subscription is active.',
 											'newspack-listings'
-										) }
+										)}
 									</p>
 									<hr />
-									<h3>{ __( 'Listing Details', 'newspack-listings' ) }</h3>
-									<label htmlFor={ `listing-title-subscription${ clientId }` }>
-										{ __( 'Listing Title', 'newspack-listings' ) }
+									<h3>
+										{__(
+											'Listing Details',
+											'newspack-listings'
+										)}
+									</h3>
+									<label
+										htmlFor={`listing-title-subscription${clientId}`}
+									>
+										{__(
+											'Listing Title',
+											'newspack-listings'
+										)}
 									</label>
 									<input
 										type="text"
-										id={ `listing-title-subscription${ clientId }` }
+										id={`listing-title-subscription${clientId}`}
 										name="listing-title-subscription"
 										value=""
-										placeholder={ __( 'My Listing Title' ) }
+										placeholder={__('My Listing Title')}
 									/>
 									<input
 										type="checkbox"
-										id={ `listing-subscription-upgrade-${ clientId }` }
+										id={`listing-subscription-upgrade-${clientId}`}
 										name="listing-premium-upgrade"
 									/>
-									<label htmlFor={ `listing-subscription-upgrade-${ clientId }` }>
-										{ __( 'Upgrade to a premium subscription', 'newspack-listings' ) }
+									<label
+										htmlFor={`listing-subscription-upgrade-${clientId}`}
+									>
+										{__(
+											'Upgrade to a premium subscription',
+											'newspack-listings'
+										)}
 									</label>
 									<p class="newspack-listings__help">
-										{ __(
+										{__(
 											'A premium subscription upgrades your listing to "featured" status and lets you create up to 10 additional Marketplace or Event listings.',
 											'newspack-listings'
-										) }
+										)}
 									</p>
 								</div>
 							</div>
-						) }
-					</div>
-					<button type="submit" onClick={ e => e.preventDefault() }>
-						<RichText
-							onChange={ value => setAttributes( { buttonText: value } ) }
-							placeholder={ __( 'Button text…', 'newspack-listings' ) }
-							value={ buttonText }
-							tagName="span"
-						/>
-					</button>
-				</form>
-			</div>
-		</>
+						)}
+				</div>
+				<button type="submit" onClick={e => e.preventDefault()}>
+					<RichText
+						onChange={value => setAttributes({ buttonText: value })}
+						placeholder={__('Button text…', 'newspack-listings')}
+						value={buttonText}
+						tagName="span"
+					/>
+				</button>
+			</form>
+		</div>
 	);
 };

--- a/src/blocks/self-serve-listings/edit.js
+++ b/src/blocks/self-serve-listings/edit.js
@@ -206,8 +206,8 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 									type="text"
 									id={ `listing-title-single-${ clientId }` }
 									name="listing-title-single"
-									value=""
 									placeholder={ __( 'My Listing Title' ) }
+									readOnly
 								/>
 								<label htmlFor={ `listing-type-${ clientId }` }>
 									{ __( 'Listing Type', 'newspack-listings' ) }
@@ -279,8 +279,8 @@ export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes }
 									type="text"
 									id={ `listing-title-subscription${ clientId }` }
 									name="listing-title-subscription"
-									value=""
 									placeholder={ __( 'My Listing Title' ) }
+									readOnly
 								/>
 								<input
 									type="checkbox"

--- a/src/blocks/self-serve-listings/edit.js
+++ b/src/blocks/self-serve-listings/edit.js
@@ -4,11 +4,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import {
-	InspectorControls,
-	RichText,
-	useBlockProps,
-} from '@wordpress/block-editor';
+import { InspectorControls, RichText, useBlockProps } from '@wordpress/block-editor';
 import {
 	BaseControl,
 	CheckboxControl,
@@ -29,13 +25,9 @@ const {
 	self_serve_listing_expiration: singleExpirationPeriod = 30,
 } = window.newspack_listings_data || {};
 
-export const SelfServeListingsEditor = ({
-	attributes,
-	clientId,
-	setAttributes,
-}) => {
-	const [selectedType, setSelectedType] = useState('single');
-	const [error, setError] = useState(null);
+export const SelfServeListingsEditor = ( { attributes, clientId, setAttributes } ) => {
+	const [ selectedType, setSelectedType ] = useState( 'single' );
+	const [ error, setError ] = useState( null );
 	const {
 		allowedSingleListingTypes,
 		allowSubscription, // Legacy attribute superseded by allowedPurchases.
@@ -45,152 +37,99 @@ export const SelfServeListingsEditor = ({
 		subscriptionDescription,
 	} = attributes;
 
-	useEffect(() => {
-		setAttributes({ clientId });
-	}, [clientId]);
+	useEffect( () => {
+		setAttributes( { clientId } );
+	}, [ clientId ] );
 
-	useEffect(() => {
-		if (false === allowSubscription) {
-			setAttributes({ allowedPurchases: 'single-only' });
+	useEffect( () => {
+		if ( false === allowSubscription ) {
+			setAttributes( { allowedPurchases: 'single-only' } );
 		}
-	}, [allowSubscription]);
+	}, [ allowSubscription ] );
 
-	const classNames = [
-		'newspack-listings__self-serve-form',
-		'wpbnbd',
-		allowedPurchases,
-	];
-	const blockProps = useBlockProps({
-		className: classNames.join(' '),
-	});
+	const classNames = [ 'newspack-listings__self-serve-form', 'wpbnbd', allowedPurchases ];
+	const blockProps = useBlockProps( {
+		className: classNames.join( ' ' ),
+	} );
 
 	const getPurchaseTypeLabel = () => {
 		switch (allowedPurchases) {
 			case 'both':
-				return __(
-					'both single listings and subscriptions',
-					'newspack-listings'
-				);
+				return __( 'both single listings and subscriptions', 'newspack-listings' );
 			case 'single-only':
-				return __('single listings only', 'newspack-listings');
+				return __( 'single listings only', 'newspack-listings' );
 			case 'subscription-only':
-				return __('subscription listings only', 'newspack-listings');
+				return __( 'subscription listings only', 'newspack-listings' );
 		}
-	};
+	}
 
 	return (
-		<div {...blockProps}>
+		<div { ...blockProps }>
 			<InspectorControls>
-				<PanelBody title={__('Self-Serve Listing Settings')}>
+				<PanelBody title={ __( 'Self-Serve Listing Settings' ) }>
 					<PanelRow>
 						<SelectControl
-							label={__(
-								'Purchase Types Allowed',
-								'newspack-listings'
-							)}
-							help={sprintf(
-								__(
-									'Allow readers to purchase %s.',
-									'newspack-listings'
-								),
+							label={ __( 'Purchase Types Allowed', 'newspack-listings' ) }
+							help={ sprintf(
+								__( 'Allow readers to purchase %s.', 'newspack-listings' ),
 								getPurchaseTypeLabel()
-							)}
-							onChange={value =>
-								setAttributes({
-									allowedPurchases: value,
-									allowSubscription: true,
-								})
-							}
-							value={
-								false === allowSubscription
-									? 'single-only'
-									: allowedPurchases
-							}
-							options={[
+							) }
+							onChange={ value => setAttributes( { allowedPurchases: value, allowSubscription: true } ) }
+							value={ false === allowSubscription ? 'single-only' : allowedPurchases }
+							options={ [
 								{
-									label: __(
-										'Single listings and subscriptions',
-										'newspack-listings'
-									),
-									value: 'both',
+									label: __( 'Single listings and subscriptions', 'newspack-listings' ),
+									value: 'both'
 								},
 								{
-									label: __(
-										'Single listings only',
-										'newspack-listings'
-									),
-									value: 'single-only',
+									label: __( 'Single listings only', 'newspack-listings' ),
+									value: 'single-only'
 								},
 								{
-									label: __(
-										'Subscriptions only',
-										'newspack-listings'
-									),
-									value: 'subscription-only',
+									label: __( 'Subscriptions only', 'newspack-listings' ),
+									value: 'subscription-only'
 								},
-							]}
+							] }
 						/>
 					</PanelRow>
-					{'subscription-only' !== allowedPurchases && (
+					{ 'subscription-only' !== allowedPurchases && (
 						<BaseControl
 							id="newspack-listings-allowed-single-listing-types"
-							help={__(
+							help={ __(
 								'Choose which listing types users are allowed to purchase.',
 								'newspack-listings'
-							)}
-							label={__(
-								'Allowed Single Listing Types',
-								'newspack-listings'
-							)}
+							) }
+							label={ __( 'Allowed Single Listing Types', 'newspack-listings' ) }
 						>
-							{singleListingTypes.map(listingType => {
-								const isAllowed =
-									allowedSingleListingTypes.reduce(
-										(acc, type) => {
-											if (
-												type.slug === listingType.slug
-											) {
-												return true;
-											}
-											return acc;
-										},
-										false
-									);
+							{ singleListingTypes.map( listingType => {
+								const isAllowed = allowedSingleListingTypes.reduce( ( acc, type ) => {
+									if ( type.slug === listingType.slug ) {
+										return true;
+									}
+									return acc;
+								}, false );
 								return (
-									<PanelRow key={listingType.slug}>
+									<PanelRow key={ listingType.slug }>
 										<CheckboxControl
-											label={listingType.name}
-											checked={isAllowed}
-											onChange={value => {
-												setError(null);
-												if (
-													(value && isAllowed) ||
-													(!value && !isAllowed)
-												) {
+											label={ listingType.name }
+											checked={ isAllowed }
+											onChange={ value => {
+												setError( null );
+												if ( ( value && isAllowed ) || ( ! value && ! isAllowed ) ) {
 													return false;
 												}
 
-												let newAllowedListingTypes = [
-													...allowedSingleListingTypes,
-												];
+												let newAllowedListingTypes = [ ...allowedSingleListingTypes ];
 
-												if (value) {
-													newAllowedListingTypes.push(
-														listingType
-													);
+												if ( value ) {
+													newAllowedListingTypes.push( listingType );
 												} else {
-													newAllowedListingTypes =
-														allowedSingleListingTypes.filter(
-															type =>
-																type.slug !==
-																listingType.slug
-														);
+													newAllowedListingTypes = allowedSingleListingTypes.filter(
+														type => type.slug !== listingType.slug
+													);
 												}
 
-												if (
-													0 ===
-													newAllowedListingTypes.length
-												) {
+												if ( 0 === newAllowedListingTypes.length ) {
 													setError(
 														__(
 															'You must allow at least one listing type for purchase.',
@@ -200,230 +139,172 @@ export const SelfServeListingsEditor = ({
 													return false;
 												}
 
-												setAttributes({
-													allowedSingleListingTypes:
-														newAllowedListingTypes,
-												});
-											}}
+												setAttributes( {
+													allowedSingleListingTypes: newAllowedListingTypes,
+												} );
+											} }
 										/>
 									</PanelRow>
 								);
-							})}
+							} ) }
 						</BaseControl>
-					)}
-					{error && (
-						<Notice
-							className="newspack-listings__error"
-							status="error"
-							isDismissible={false}
-						>
-							{error}
+					) }
+					{ error && (
+						<Notice className="newspack-listings__error" status="error" isDismissible={ false }>
+							{ error }
 						</Notice>
-					)}
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<form>
 				<div className="frequencies">
-					{('subscription-only' !== allowedPurchases ||
-						false === allowSubscription) && (
+					{ ( 'subscription-only' !== allowedPurchases || false === allowSubscription ) && (
 						<div className="newspack-listings__form-tabs frequency">
 							<input
 								name="listing-purchase-type"
 								className="newspack-listings__tab-input"
-								id={`listing-single-${clientId}`}
+								id={ `listing-single-${ clientId }` }
 								type="radio"
 								value="listing-single"
-								checked={
-									'single' === selectedType ||
-									'single-only' === allowedPurchases ||
-									false === allowSubscription
-								}
-								onClick={() => setSelectedType('single')}
+								checked={ 'single' === selectedType || 'single-only' === allowedPurchases || false === allowSubscription }
+								onClick={ () => setSelectedType( 'single' ) }
 							/>
 							<label
 								className="freq-label listing-single"
 								htmlFor="listing-single"
-								onClick={() => setSelectedType('single')}
+								onClick={ () => setSelectedType( 'single' ) }
 							>
-								{__('Single Listing')}
+								{ __( 'Single Listing' ) }
 							</label>
 							<div className="input-container listing-details">
 								<RichText
-									onChange={value =>
-										setAttributes({
-											singleDescription: value,
-										})
-									}
-									placeholder={__(
+									onChange={ value => setAttributes( { singleDescription: value } ) }
+									placeholder={ __(
 										'Description text for your single listing product…',
 										'newspack-listings'
-									)}
-									value={singleDescription}
+									) }
+									value={ singleDescription }
 									tagName="p"
 								/>
-								{singleExpirationPeriod && (
+								{ singleExpirationPeriod && (
 									<p className="newspack-listings__help">
-										{sprintf(
+										{ sprintf(
 											__(
 												'Single-purchase listings expire %d days after the date of publication.',
 												'newspack-listings'
 											),
 											singleExpirationPeriod
-										)}
+										) }
 									</p>
-								)}
+								) }
 								<hr />
-								<h3>
-									{__('Listing Details', 'newspack-listings')}
-								</h3>
-								<label
-									htmlFor={`listing-title-single-${clientId}`}
-								>
-									{__('Listing Title', 'newspack-listings')}
+								<h3>{ __( 'Listing Details', 'newspack-listings' ) }</h3>
+								<label htmlFor={ `listing-title-single-${ clientId }` }>
+									{ __( 'Listing Title', 'newspack-listings' ) }
 								</label>
 								<input
 									type="text"
-									id={`listing-title-single-${clientId}`}
+									id={ `listing-title-single-${ clientId }` }
 									name="listing-title-single"
 									value=""
-									placeholder={__('My Listing Title')}
+									placeholder={ __( 'My Listing Title' ) }
 								/>
-								<label htmlFor={`listing-type-${clientId}`}>
-									{__('Listing Type', 'newspack-listings')}
+								<label htmlFor={ `listing-type-${ clientId }` }>
+									{ __( 'Listing Type', 'newspack-listings' ) }
 								</label>
-								<select
-									id={`${clientId}`}
-									name="listing-single-type"
-								>
-									{allowedSingleListingTypes.map(
-										listingType => (
-											<option
-												key={listingType.slug}
-												value={`listing-type-${listingType.slug}`}
-											>
-												{listingType.name}
-											</option>
-										)
-									)}
+								<select id={ `${ clientId }` } name="listing-single-type">
+									{ allowedSingleListingTypes.map( listingType => (
+										<option key={ listingType.slug } value={ `listing-type-${ listingType.slug }` }>
+											{ listingType.name }
+										</option>
+									) ) }
 								</select>
 								<input
 									type="checkbox"
-									id={`listing-single-upgrade-${clientId}`}
+									id={ `listing-single-upgrade-${ clientId }` }
 									name="listing-featured-upgrade"
 								/>
-								<label
-									htmlFor={`listing-single-upgrade-${clientId}`}
-								>
-									{__(
-										'Upgrade to a featured listing',
-										'newspack-listings'
-									)}
+								<label htmlFor={ `listing-single-upgrade-${ clientId }` }>
+									{ __( 'Upgrade to a featured listing', 'newspack-listings' ) }
 								</label>
 								<p class="newspack-listings__help">
-									{__(
+									{ __(
 										'Featured listings appear first in lists, directory pages and search results.',
 										'newspack-listings'
-									)}
+									) }
 								</p>
 							</div>
 						</div>
-					)}
-					{'single-only' !== allowedPurchases &&
-						false !== allowSubscription && (
-							<div className="newspack-listings__form-tabs frequency">
-								<input
-									name="listing-purchase-type"
-									className="newspack-listings__tab-input"
-									id={`listing-subscription-${clientId}`}
-									type="radio"
-									value="listing-subscription"
-									checked={
-										'subscription' === selectedType ||
-										'subscription-only' === allowedPurchases
-									}
-									onClick={() =>
-										setSelectedType('subscription')
-									}
+					) }
+					{ ( 'single-only' !== allowedPurchases && false !== allowSubscription ) && (
+						<div className="newspack-listings__form-tabs frequency">
+							<input
+								name="listing-purchase-type"
+								className="newspack-listings__tab-input"
+								id={ `listing-subscription-${ clientId }` }
+								type="radio"
+								value="listing-subscription"
+								checked={ 'subscription' === selectedType || 'subscription-only' === allowedPurchases }
+								onClick={ () => setSelectedType( 'subscription' ) }
+							/>
+							<label
+								className="freq-label listing-subscription"
+								htmlFor="listing-subscription"
+								onClick={ () => setSelectedType( 'subscription' ) }
+							>
+								{ __( 'Listing Subscription' ) }
+							</label>
+							<div className="input-container listing-details">
+								<RichText
+									onChange={ value => setAttributes( { subscriptionDescription: value } ) }
+									placeholder={ __(
+										'Description text for your subscription product…',
+										'newspack-listings'
+									) }
+									value={ subscriptionDescription }
+									tagName="p"
 								/>
-								<label
-									className="freq-label listing-subscription"
-									htmlFor="listing-subscription"
-									onClick={() =>
-										setSelectedType('subscription')
-									}
-								>
-									{__('Listing Subscription')}
+								<p className="newspack-listings__help">
+									{ __(
+										'Subscription listings remain live as long as the subscription is active.',
+										'newspack-listings'
+									) }
+								</p>
+								<hr />
+								<h3>{ __( 'Listing Details', 'newspack-listings' ) }</h3>
+								<label htmlFor={ `listing-title-subscription${ clientId }` }>
+									{ __( 'Listing Title', 'newspack-listings' ) }
 								</label>
-								<div className="input-container listing-details">
-									<RichText
-										onChange={value =>
-											setAttributes({
-												subscriptionDescription: value,
-											})
-										}
-										placeholder={__(
-											'Description text for your subscription product…',
-											'newspack-listings'
-										)}
-										value={subscriptionDescription}
-										tagName="p"
-									/>
-									<p className="newspack-listings__help">
-										{__(
-											'Subscription listings remain live as long as the subscription is active.',
-											'newspack-listings'
-										)}
-									</p>
-									<hr />
-									<h3>
-										{__(
-											'Listing Details',
-											'newspack-listings'
-										)}
-									</h3>
-									<label
-										htmlFor={`listing-title-subscription${clientId}`}
-									>
-										{__(
-											'Listing Title',
-											'newspack-listings'
-										)}
-									</label>
-									<input
-										type="text"
-										id={`listing-title-subscription${clientId}`}
-										name="listing-title-subscription"
-										value=""
-										placeholder={__('My Listing Title')}
-									/>
-									<input
-										type="checkbox"
-										id={`listing-subscription-upgrade-${clientId}`}
-										name="listing-premium-upgrade"
-									/>
-									<label
-										htmlFor={`listing-subscription-upgrade-${clientId}`}
-									>
-										{__(
-											'Upgrade to a premium subscription',
-											'newspack-listings'
-										)}
-									</label>
-									<p class="newspack-listings__help">
-										{__(
-											'A premium subscription upgrades your listing to "featured" status and lets you create up to 10 additional Marketplace or Event listings.',
-											'newspack-listings'
-										)}
-									</p>
-								</div>
+								<input
+									type="text"
+									id={ `listing-title-subscription${ clientId }` }
+									name="listing-title-subscription"
+									value=""
+									placeholder={ __( 'My Listing Title' ) }
+								/>
+								<input
+									type="checkbox"
+									id={ `listing-subscription-upgrade-${ clientId }` }
+									name="listing-premium-upgrade"
+								/>
+								<label htmlFor={ `listing-subscription-upgrade-${ clientId }` }>
+									{ __( 'Upgrade to a premium subscription', 'newspack-listings' ) }
+								</label>
+								<p class="newspack-listings__help">
+									{ __(
+										'A premium subscription upgrades your listing to "featured" status and lets you create up to 10 additional Marketplace or Event listings.',
+										'newspack-listings'
+									) }
+								</p>
 							</div>
-						)}
+						</div>
+					) }
 				</div>
-				<button type="submit" onClick={e => e.preventDefault()}>
+				<button type="submit" onClick={ e => e.preventDefault() }>
 					<RichText
-						onChange={value => setAttributes({ buttonText: value })}
-						placeholder={__('Button text…', 'newspack-listings')}
-						value={buttonText}
+						onChange={ value => setAttributes( { buttonText: value } ) }
+						placeholder={ __( 'Button text…', 'newspack-listings' ) }
+						value={ buttonText }
 						tagName="span"
 					/>
 				</button>

--- a/src/blocks/self-serve-listings/index.js
+++ b/src/blocks/self-serve-listings/index.js
@@ -14,6 +14,7 @@ const { attributes, category, name } = metadata;
 
 export const registerSelfServeListingsBlock = () => {
 	registerBlockType( name, {
+		apiVersion: 3,
 		title: __( 'Listings: Self-Serve Form', 'newspack-listings' ),
 		icon: {
 			src: pencil,

--- a/src/blocks/self-serve-listings/view.php
+++ b/src/blocks/self-serve-listings/view.php
@@ -15,17 +15,9 @@ use Newspack_Listings\Utils;
  * Dynamic block registration.
  */
 function register_block() {
-	// Block attributes.
-	$block_json = json_decode(
-		file_get_contents( __DIR__ . '/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		true
-	);
-
-	// Register Price block.
 	register_block_type(
-		$block_json['name'],
+		__DIR__,
 		[
-			'attributes'      => $block_json['attributes'],
 			'render_callback' => __NAMESPACE__ . '\render_block',
 		]
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR reworks several blocks in this plugin for compatibility with the new iframe-based Post Editor:

* newspack-listings/curated-list
* newspack-listings/list-container
* newspack-listings/event-dates
* newspack-listings/price
* newspack-listings/self-serve-listings
* newspack-listings/event
* newspack-listings/generic
* newspack-listings/marketplace
* newspack-listings/place

Addresses [NPPM-2589: Newspack Listings (iframe Editor Compatibility)](https://linear.app/a8c/issue/NPPM-2589/newspack-listings-iframe-editor-compatibility).

### How to test the changes in this Pull Request:

#### General Prerequisites:

1. Set up a basic test site with only `newspack-plugin` and `newspack-listings` enabled.
2. Create test listings (*Listings* item in admin sidebar)--at least two of each:
  * Event
  * Marketplace (add a `Price` block to at least one)
  * Generic
  * Places
3. Verify each listing shows up as expected outside the editor.
5. Inspect the DOM to make sure you're in the non-iframe editor--none of the ancestors of the blocks you're editing should be an `<iframe>`.
3. Create a test post with:
  * 'Curated List' block, and choose a `Query` list.
  * 'Curated List' block, `Specific Listings` list, and select a few listings you created using the `+` at the bottom.
4. Verify that:
  * Selectors worked for each scenario.
  * The listings you selected show up in the editor.
  * The listings show up outside the editor.

#### Experimental prerequisites:  Self-serve listings (released as an experimental feature)
In addition to the above:
1. Install WooCommerce and WooCommerce Subscriptions (premium plugin, manual install).
2. (Maybe optional?) Enable a payment type--check payments should be fine for testing.
3. Set `NEWSPACK_LISTINGS_SELF_SERVE_ENABLED` to `true` however you like--for example, in `wp-config.php`:
```
define( 'NEWSPACK_LISTINGS_SELF_SERVE_ENABLED', true );
```
4. Configure self-serve listings [per the docs](https://help.newspack.com/engagement/listings/#experimental-features).  (Mainly, click the link in *Listings > Settings* under 'Self-Serve Settings' to enable.)
5. Add the 'Listings: Self-Serve Form' block to a test post.  Leave 'Purchase Types Allowed' on the default of `Single listings and subscriptions` to test the tabs.
6. Inspect the DOM to make sure you're in the non-iframe editor--none of the ancestors of the blocks you're editing should be an `<iframe>`.
7. Verify in the editor that:
  * The tabs properly toggle between the single listing and subscription forms.
  * Selectors show appropriate options.
8. Verify outside the editor that:
  * The tabs still toggle properly.
  * Information entered in the selectors and text fields are reflected when you submit the form.


#### Testing standard blocks:
1. Apply this PR.
2. Create a new Marketplace listing, and add a 'Price' block.
3. Verify that the editor pane is an `<iframe>` in the DOM.
4. Verify the 'Price' block shows up properly in the editor and on the post itself.
5. Create a new post.
6. Again, verify the editor is iframed.
7. Add blocks:
  * 'Curated List' block, and choose a `Query` list.
  * 'Curated List' block, `Specific Listings` list, and select a few listings you created using the `+` at the bottom.
8. Verify that:
  * Selectors show appropriate options.
  * The listings you select show up in the editor.
  * The listings show up outside the editor.

#### Testing self-serve listings form:

1. Make sure you've gone through the *Experimental Prerequisites* above.
2. Apply this PR.
3. Add the 'Listings: Self-Serve Form' block to a test post.  Leave 'Purchase Types Allowed' on the default of `Single listings and subscriptions` to test the tabs.
4. Verify you're in the iframe editor by checking the DOM--you should see an iframe where the edit pane would be.
5. Verify in the editor that:
  * The tabs properly toggle between the single listing and subscription forms.
  * Selectors show appropriate options.
6. Verify outside the editor that:
  * The tabs still toggle properly.
  * Information entered in the selectors and text fields are reflected when you submit the form.

#### Testing existing blocks (the upgrade case):
1. Apply this PR if you haven't already.
4. View the posts you created before applying the PR.
5. Do the existing blocks continue to work as expected?
8. Is the same true when viewing the post outside the editor?

### Known issues:
* The tabs have a preexisting issue where they wind up halfway between tabs and stacked radio buttons at narrow window widths; iframing the block can change the available width a bit and make this more prominent.  We should explore this in a separate PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->