### PR TITLE
chore: import PluginDocumentSettingPanel from @wordpress/editor

### DIFF
--- a/src/editor/featured-listings/index.js
+++ b/src/editor/featured-listings/index.js
@@ -7,7 +7,7 @@ import { BaseControl, Button, DatePicker, PanelRow, RangeControl, ToggleControl 
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { dateI18n } from '@wordpress/date';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -5,7 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { BaseControl, DateTimePicker, ExternalLink, PanelRow, ToggleControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`PluginDocumentSettingPanel` was relocated from `@wordpress/edit-post` to `@wordpress/editor` in WP 6.6. The `edit-post` re-export still works today but emits a deprecation warning and is a candidate for removal in a future release.

Listing post editor sidebar (Hide author/Hide date/Expiration date) and Featured Listing sidebar (Featured toggle/Priority/Featured expiration) both use the component and are unchanged in appearance and behavior.

### How to test the changes in this Pull Request:

1. Make sure your site is on 7.0 RC2
2. On a site running this branch, edit any listing CPT post (Event, Generic, Marketplace, Place).
3. Open the document settings sidebar — confirm the **Listing Settings** panel renders, including the Hide listing author/Hide publish date toggles and the Expiration Date picker.
4. Toggle each control, save the post, reload, and verify values persist.
5. Edit any non-listing post (regular post or page). Confirm the **Featured Listing Settings** panel renders in the document sidebar with the Featured Listing toggle.
6. Toggle Featured on, set a Priority (1-9), set an Expiration Date, save, and verify priority persists across reload (priority is stored in `wp_newspack_listings_priority`, not post meta).
7. Open the browser console while editing a listing — confirm no React errors and no deprecation warnings about `PluginDocumentSettingPanel`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?